### PR TITLE
FIXES style and text spacing and length related tickets

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,6 +1,6 @@
-<bae-header class="fixed w-full z-30 top-0 start-0"></bae-header>
+<bae-header class="fixed w-full z-50 top-0 start-0"></bae-header>
 <bae-categories-panel class="fixed z-30 w-full top-[72px] transition transform opacity-0 duration-200" [ngClass]="showPanel ? 'opacity-100' : 'hidden'"></bae-categories-panel>
-<main class="bg-fixed bg-no-repeat bg-right pb-[25px]" [ngClass]="showPanel ? 'pt-[121px]' : 'pt-[75px]'">
+<main class="bg-fixed bg-no-repeat bg-right pb-[25px]" [ngClass]="showPanel ? 'pt-[130px]' : 'pt-[75px]'">
     <router-outlet></router-outlet>
 </main>
 <app-chatbot-widget class="relative"></app-chatbot-widget>

--- a/src/app/offerings/how-it-works/how-it-works.component.html
+++ b/src/app/offerings/how-it-works/how-it-works.component.html
@@ -1,11 +1,11 @@
-<div class="py-8 px-4 mx-auto max-w-screen-xl lg:py-16">
+<div class="mx-auto max-w-screen-xl">
     <h2 class="pb-2 text-4xl font-extrabold text-primary-100 mb-4 text-center dark:text-primary-50">{{ 'HOWITWORKS._title' | translate }}</h2>
     <p class="mb-8 text-lg font-normal text-gray-500 lg:text-xl sm:px-16 xl:px-48 dark:text-secondary-50 text-center">{{ 'HOWITWORKS._subtitle' | translate }}</p>
 
     <div class="grid lg:grid-cols-2 gap-8 sm:grid-cols-1">
         <!-- CUSTOMERS -->
-        <div class="border border-primary-100 dark:border-primary-50 rounded-lg p-8 md:p-12">
-            <div class="grid grid-cols-80/20 pb-4 h-1/4 mb-2">
+        <div class="border border-primary-100 dark:border-primary-50 rounded-lg p-4 md:p-8">
+            <div class="grid grid-cols-80/20">
                 <div class="flex justify-start grid grid-rows-20/80">
                     <h2 class="text-gray-900 dark:text-white text-xl font-normal mb-2">{{ 'HOWITWORKS.CUSTOMERS._title' | translate }}</h2>
                     <h2 class="text-gray-900 dark:text-white text-3xl font-extrabold">{{ 'HOWITWORKS.CUSTOMERS._subtitle' | translate }}</h2>
@@ -15,39 +15,16 @@
                 </div>
             </div>
             
-            <div class="h-2/4 text-lg font-normal text-gray-500 dark:text-gray-400 mb-4">
-                <ol class="max-w-md space-y-1 list-decimal list-inside mb-4">
-                    <li>
-                        <span class="font-semibold text-primary-100 dark:text-primary-50">{{ 'HOWITWORKS.CUSTOMERS._search_title' | translate }}:</span> {{ 'HOWITWORKS.CUSTOMERS._search_desc' | translate }}
-                    </li>
-                    <li>
-                        <span class="font-semibold text-primary-100 dark:text-primary-50">{{ 'HOWITWORKS.CUSTOMERS._compare_title' | translate }}:</span> {{ 'HOWITWORKS.CUSTOMERS._compare_desc' | translate }}
-                    </li>
-                    <li>
-                        <span class="font-semibold text-primary-100 dark:text-primary-50">{{ 'HOWITWORKS.CUSTOMERS._seamless_title' | translate }}:</span> {{ 'HOWITWORKS.CUSTOMERS._seamless_desc' | translate }}
-                    </li>
-                </ol>
-                  
-            </div>
-
-            <div class="flex h-1/4 items-end justify-between">
-
-                <button type="button" (click)="contact()" class="h-fit text-blue-600 dark:text-blue-500 hover:text-white border border-primary-100 dark:border-primary-50 hover:bg-primary-100 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center inline-flex items-center me-2 dark:text-primary-50 dark:hover:text-white dark:hover:bg-primary-50 dark:focus:ring-blue-800">
-                    {{ 'HOWITWORKS.CUSTOMERS._contact' | translate }}
-                </button>
-
-                <button type="button" (click)="goTo('/search')" class="h-fit text-blue-600 dark:text-blue-500 hover:text-white border border-primary-100 dark:border-primary-50 hover:bg-primary-100 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center inline-flex items-center me-2 dark:text-primary-50 dark:hover:text-white dark:hover:bg-primary-50 dark:focus:ring-blue-800">
-                    <!--<svg class="w-3.5 h-3.5 mr-2" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 10">
-                        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M1 5h12m0 0L9 1m4 4L9 9"/>
-                    </svg>-->
-                    {{ 'HOWITWORKS.CUSTOMERS._explore' | translate }}
-                </button>
+            <div class="text-lg font-normal text-gray-500 dark:text-gray-400">
+                <p>
+                    {{ 'HOWITWORKS.CUSTOMERS._description' | translate }}
+                </p>
             </div>
 
         </div>
         <!-- PROVIDERS -->
-        <div class="border border-primary-100 dark:border-primary-50 rounded-lg p-8 md:p-12">
-            <div class="grid grid-cols-80/20 pb-4 h-1/4 mb-2">
+        <div class="border border-primary-100 dark:border-primary-50 rounded-lg p-4 md:p-8">
+            <div class="grid grid-cols-80/20">
                 <div class="flex justify-start grid grid-rows-20/80">
                     <h2 class="text-gray-900 dark:text-white text-xl font-normal mb-2">{{ 'HOWITWORKS.PROVIDERS._title' | translate }}</h2>
                     <h2 class="text-gray-900 dark:text-white text-3xl font-extrabold">{{ 'HOWITWORKS.PROVIDERS._subtitle' | translate }}</h2>
@@ -57,33 +34,15 @@
                 </div>
             </div>
             
-            <div class="h-2/4 text-lg font-normal text-gray-500 dark:text-gray-400 mb-4">
-                <ol class="max-w-md space-y-1 list-decimal list-inside mb-4">
-                    <li>
-                        <span class="font-semibold text-primary-100 dark:text-primary-50">{{ 'HOWITWORKS.PROVIDERS._register_title' | translate }}:</span> {{ 'HOWITWORKS.PROVIDERS._register_desc' | translate }}
-                    </li>
-                    <li>
-                        <span class="font-semibold text-primary-100 dark:text-primary-50">{{ 'HOWITWORKS.PROVIDERS._verified_title' | translate }}:</span> {{ 'HOWITWORKS.PROVIDERS._verified_desc' | translate }}
-                    </li>
-                    <li>
-                        <span class="font-semibold text-primary-100 dark:text-primary-50">{{ 'HOWITWORKS.PROVIDERS._reach_title' | translate }}:</span> {{ 'HOWITWORKS.PROVIDERS._reach_desc' | translate }}
-                    </li>
-                </ol>
-                  
-            </div>
-
-            <div class="flex h-1/4 items-end justify-between">
-
-                <button type="button" (click)="contact()" target="_blank" class="h-fit text-blue-600 dark:text-blue-500 hover:text-white border border-primary-100 dark:border-primary-50 hover:bg-primary-100 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center inline-flex items-center me-2 dark:text-primary-50 dark:hover:text-white dark:hover:bg-primary-50 dark:focus:ring-blue-800">
-                    {{ 'HOWITWORKS.PROVIDERS._contact' | translate }}
-                </button>
-
-                <!--<button type="button" class="h-fit text-blue-600 dark:text-blue-500 hover:text-white border border-primary-100 dark:border-primary-50 hover:bg-primary-100 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center inline-flex items-center me-2 dark:text-primary-50 dark:hover:text-white dark:hover:bg-primary-50 dark:focus:ring-blue-800">
-                    <svg class="w-3.5 h-3.5 mr-2" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 10">
-                        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M1 5h12m0 0L9 1m4 4L9 9"/>
-                    </svg>
-                    {{ 'HOWITWORKS.PROVIDERS._onboard' | translate }}
-                </button>-->
+            <div class="text-lg font-normal text-gray-500 dark:text-gray-400">
+                <p>
+                    {{ 'HOWITWORKS.PROVIDERS._description_start' | translate }}
+                    <a href="https://knowledgebase.dome-marketplace.org/shelves/company-onboarding-process" target="_blank"
+                    class="font-medium mr-1 text-blue-600 dark:text-blue-500 hover:underline">
+                        {{ 'HOWITWORKS.PROVIDERS._link' | translate }}
+                    </a>
+                    {{ 'HOWITWORKS.PROVIDERS._description_end' | translate }}
+                </p>
             </div>
         </div>
     </div>

--- a/src/app/pages/admin/categories/create-category/create-category.component.html
+++ b/src/app/pages/admin/categories/create-category/create-category.component.html
@@ -145,7 +145,7 @@
                             <div class="px-4 py-2 bg-white dark:bg-secondary-300 rounded-b-lg">
                                 <label for="editor" class="sr-only">Publish post</label>
                                 @if(showPreview){
-                                        <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900" [data]="description"></markdown>
+                                        <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900 text-wrap break-all" [data]="description"></markdown>
                                     
                                 }@else{
                                     <textarea id="editor" formControlName="description" rows="8" class="block w-full px-0 text-sm text-gray-800 dark:text-gray-200 bg-white dark:bg-secondary-300 border-0" placeholder="Add product description..." ></textarea>
@@ -159,7 +159,7 @@
                         <label class="font-bold text-lg dark:text-white">{{ 'CREATE_CATEGORIES._choose_parent' | translate }}</label>
                         <label class="inline-flex items-center me-5 cursor-pointer ml-4">
                             <input type="checkbox" (change)="toggleParent()" [checked]="parentSelectionCheck" class="sr-only peer">
-                            <div class="relative w-11 h-6 bg-gray-200 rounded-full peer peer-focus:ring-4 peer-focus:ring-primary-100 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary-100"></div>
+                            <div class="relative w-11 h-6 bg-gray-400 dark:bg-gray-700 rounded-full peer peer-focus:ring-4 peer-focus:ring-primary-100 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary-100"></div>
                         </label>
                         @if(parentSelectionCheck){
                             @if(categories.length==0){
@@ -192,7 +192,7 @@
                                 <tbody>
                                     @for (cat of categories; track cat.id;let idx = $index) {
                                         <tr class="flex border-b dark:border-gray-700 hover:bg-gray-200 w-full justify-between dark:bg-secondary-300 dark:hover:bg-secondary-200">
-                                            <td class="flex px-6 py-4 w-3/5">
+                                            <td class="flex px-6 py-4 w-3/5 text-wrap break-all">
                                                 <b>{{cat.name}}</b>
                                             </td>
                                             <td class="hidden md:flex px-6 py-4 w-fit">
@@ -234,7 +234,7 @@
                 <div class="m-8">
                     <div>
                         <label class="font-bold text-lg dark:text-white">{{ 'CREATE_CATEGORIES._name' | translate }}</label>
-                        <label class="mb-2 bg-gray-50 border border-gray-300 text-gray-900 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                        <label class="mb-2 bg-gray-50 text-wrap break-all border border-gray-300 text-gray-900 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
                             {{categoryToCreate?.name}}
                         </label>
                     </div>
@@ -255,14 +255,14 @@
                     @if(categoryToCreate?.description !=''){
                         <label class="font-bold text-lg dark:text-white">{{ 'CREATE_CATEGORIES._description' | translate }}</label>
                         <div class="px-4 py-2 bg-white dark:bg-secondary-300 border dark:border-secondary-200 rounded-lg p-4 mb-4">
-                            <markdown class="bg-gray-50 dark:bg-secondary-100 dark:text-white text-gray-900" [data]="categoryToCreate?.description"></markdown>
+                            <markdown class="bg-gray-50 dark:bg-secondary-100 dark:text-white text-gray-900 text-wrap break-all" [data]="categoryToCreate?.description"></markdown>
                         </div>
                     }
 
                     @if(isParent==false){
                         <label class="font-bold text-lg dark:text-white">{{ 'CREATE_CATEGORIES._parent' | translate }}</label>
                         <div class="px-4 py-2 bg-white border border-1 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white rounded-lg p-4 mb-4">
-                            <label class="text-base dark:text-white">{{selectedCategory.name}}</label>
+                            <label class="text-base dark:text-white text-wrap break-all">{{selectedCategory.name}}</label>
                         </div>                        
                     }
                     

--- a/src/app/pages/admin/categories/update-category/update-category.component.html
+++ b/src/app/pages/admin/categories/update-category/update-category.component.html
@@ -223,7 +223,7 @@
                             <div class="px-4 py-2 bg-white dark:bg-secondary-300 rounded-b-lg">
                                 <label for="editor" class="sr-only">Publish post</label>
                                 @if(showPreview){
-                                        <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900" [data]="description"></markdown>
+                                        <markdown class="bg-gray-50 text-wrap break-all dark:bg-secondary-300 dark:text-white text-gray-900" [data]="description"></markdown>
                                     
                                 }@else{
                                     <textarea id="editor" formControlName="description" rows="8" class="block w-full px-0 text-sm text-gray-800 dark:text-gray-200 bg-white dark:bg-secondary-300 border-0" placeholder="Add product description..." ></textarea>
@@ -237,7 +237,7 @@
                         <label class="font-bold text-lg dark:text-white">{{ 'UPDATE_CATEGORIES._choose_parent' | translate }}</label>
                         <label class="inline-flex items-center me-5 cursor-pointer ml-4">
                             <input type="checkbox" (change)="toggleParent()" [disabled]="checkDisableParent" [checked]="parentSelectionCheck" class="sr-only peer">
-                            <div class="relative w-11 h-6 bg-gray-200 rounded-full peer peer-focus:ring-4 peer-focus:ring-primary-100 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary-100"></div>
+                            <div class="relative w-11 h-6 bg-gray-400 dark:bg-gray-700 rounded-full peer peer-focus:ring-4 peer-focus:ring-primary-100 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary-100"></div>
                         </label>
                         @if(parentSelectionCheck){
                             @if(categories.length==0){
@@ -270,7 +270,7 @@
                                 <tbody>
                                     @for (cat of categories; track cat.id;let idx = $index) {
                                         <tr class="flex border-b dark:border-gray-700 hover:bg-gray-200 w-full justify-between dark:bg-secondary-300 dark:hover:bg-secondary-200">
-                                            <td class="flex px-6 py-4 w-3/5">
+                                            <td class="flex px-6 py-4 w-3/5 text-wrap break-all">
                                                 <b>{{cat.name}}</b>
                                             </td>
                                             <td class="hidden md:flex px-6 py-4 w-fit">
@@ -312,7 +312,7 @@
                 <div class="m-8">
                     <div>
                         <label class="font-bold text-lg dark:text-white">{{ 'UPDATE_CATEGORIES._name' | translate }}</label>
-                        <label class="mb-2 bg-gray-50 border border-gray-300 text-gray-900 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                        <label class="mb-2 bg-gray-50 text-wrap break-all border border-gray-300 text-gray-900 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
                             {{categoryToUpdate?.name}}
                         </label>
                     </div>
@@ -333,14 +333,14 @@
                     @if(categoryToUpdate?.description !=''){
                         <label class="font-bold text-lg dark:text-white">{{ 'UPDATE_CATEGORIES._description' | translate }}</label>
                         <div class="px-4 py-2 bg-white dark:bg-secondary-300 border dark:border-secondary-200 rounded-lg p-4 mb-4">
-                            <markdown class="bg-gray-50 dark:bg-secondary-100 dark:text-white text-gray-900" [data]="categoryToUpdate?.description"></markdown>
+                            <markdown class="bg-gray-50 text-wrap break-all dark:bg-secondary-100 dark:text-white text-gray-900" [data]="categoryToUpdate?.description"></markdown>
                         </div>
                     }
 
                     @if(isParent==false){
                         <label class="font-bold text-lg dark:text-white">{{ 'UPDATE_CATEGORIES._parent' | translate }}</label>
                         <div class="px-4 py-2 bg-white border dark:bg-secondary-300 dark:border-secondary-200 rounded-lg p-4 mb-4">
-                            <label class="text-base dark:text-white">{{selectedCategory.name}}</label>
+                            <label class="text-base dark:text-white text-wrap break-all">{{selectedCategory.name}}</label>
                         </div>                        
                     }
                     

--- a/src/app/pages/catalogs/catalogs.component.html
+++ b/src/app/pages/catalogs/catalogs.component.html
@@ -35,14 +35,14 @@
 
                 <div (click)="goToCatalogSearch(cat.id)" class="block cursor-pointer rounded-lg bg-cover" style="background-image: url(assets/logos/dome-logo-element-colour.png);" >
                     <div class="block w-full h-full p-6 bg-opacity-100 bg-secondary-50 rounded-lg dark:bg-secondary-100 bg-secondary-50/90 dark:bg-secondary-100/90 bg-cover">
-                        <h5 class="text-2xl font-bold tracking-tight text-primary-100 dark:text-white">{{cat.name}}</h5>
-                        <p class="font-normal text-gray-700 dark:text-gray-400 line-clamp-3">{{cat.description ? cat.description : 'CATALOGS._no_desc' | translate}}</p>
+                        <h5 class="text-2xl font-bold tracking-tight text-primary-100 dark:text-white text-wrap break-all">{{cat.name}}</h5>
+                        <p class="font-normal text-gray-700 dark:text-gray-400 line-clamp-3 text-wrap break-all">{{cat.description ? cat.description : 'CATALOGS._no_desc' | translate}}</p>
                         <hr class="h-px my-1 bg-primary-100 border-0 dark:bg-primary-100">
                         <div class="">
                           @for(category of cat.category; track category.id) {
-                            <span class="inline-block bg-blue-300 text-primary-100 text-xs font-bold me-2 px-2.5 py-0.5 rounded-full w-fit">{{category.name}}</span>
+                            <span class="inline-block bg-blue-300 text-primary-100 text-xs font-bold me-2 px-2.5 py-0.5 rounded-full w-fit text-wrap break-all">{{category.name}}</span>
                           } @empty {
-                            <span class="inline-block bg-blue-300 text-primary-100 text-xs font-bold me-2 px-2.5 py-0.5 rounded-full w-fit">{{'CATALOGS._no_cat' | translate}}</span>                            
+                            <span class="inline-block bg-blue-300 text-primary-100 text-xs font-bold me-2 px-2.5 py-0.5 rounded-full w-fit text-wrap break-all">{{'CATALOGS._no_cat' | translate}}</span>                            
                           }
                         </div>
 

--- a/src/app/pages/product-details/product-details.component.html
+++ b/src/app/pages/product-details/product-details.component.html
@@ -258,29 +258,29 @@
                         @for (price of productOff?.productOfferingPrice; track price.id) {
                             @if (price.priceType == 'recurring') {
                                 <div class="max-w-sm bg-white dark:bg-secondary-200 dark:border-gray-800 border border-gray-200 rounded-lg shadow w-full">
-                                    <div class="bg-green-500 rounded-t-lg w-full">
+                                    <div class="bg-green-500 rounded-t-lg w-full text-wrap break-all">
                                         <h5 class="flex justify-center mb-2 p-6 text-2xl font-bold tracking-tight text-gray-900 w-full">{{price.name}}</h5>
                                     </div>
                                     <p class="flex justify-center font-normal text-gray-700 dark:text-white"> <b class="text-xl mr-2">{{price.price?.value}}</b> {{price.price?.unit}}</p>
                                     <p class="flex justify-center font-normal text-gray-700 dark:text-white">/{{price.recurringChargePeriodType}}</p>
-                                    <p class="flex justify-center mb-2 p-2 font-normal text-gray-700 dark:text-white">{{price.description}}</p>
+                                    <p class="flex justify-center mb-2 p-2 font-normal text-gray-700 dark:text-white text-wrap break-all">{{price.description}}</p>
                                 </div>
                             } @else if (price.priceType == 'usage') {
                                 <div class="max-w-sm bg-white border border-gray-200 dark:bg-secondary-200 dark:border-gray-800 rounded-lg shadow w-full">
                                     <div class="bg-yellow-300 rounded-t-lg w-full">
-                                        <h5 class="flex justify-center mb-2 p-6 text-2xl font-bold tracking-tight text-gray-900">{{price.name}}</h5>
+                                        <h5 class="flex justify-center mb-2 p-6 text-2xl font-bold tracking-tight text-gray-900 text-wrap break-all">{{price.name}}</h5>
                                     </div>
                                     <p class="flex justify-center font-normal text-gray-700 dark:text-white"> <b class="text-xl mr-2">{{price.price?.value}}</b> {{price.price?.unit}}</p>
                                     <p class="flex justify-center font-normal text-gray-700 dark:text-white">/{{price.unitOfMeasure?.units}}</p>
-                                    <p class="flex justify-center mb-2 p-4 font-normal text-gray-700 dark:text-white">{{price.description}}</p>
+                                    <p class="flex justify-center mb-2 p-4 font-normal text-gray-700 dark:text-white text-wrap break-all">{{price.description}}</p>
                                 </div>
                             } @else {
                                 <div class="max-w-sm bg-white border border-gray-200 dark:bg-secondary-200 dark:border-gray-800 rounded-lg shadow w-full">
                                     <div class="bg-blue-500 rounded-t-lg w-full">
-                                        <h5 class="flex justify-center mb-4 p-6 text-2xl font-bold tracking-tight text-gray-900">{{price.name}}</h5>
+                                        <h5 class="flex justify-center mb-4 p-6 text-2xl font-bold tracking-tight text-gray-900 text-wrap break-all">{{price.name}}</h5>
                                     </div>
                                     <p class="flex justify-center font-normal text-gray-700 dark:text-white"> <b class="text-xl mr-2">{{price.price?.value}}</b> {{price.price?.unit}}</p>
-                                    <p class="flex justify-center mb-2 p-4 font-normal text-gray-700 dark:text-white">{{price.description}}</p>
+                                    <p class="flex justify-center mb-2 p-4 font-normal text-gray-700 dark:text-white text-wrap break-all">{{price.description}}</p>
                                 </div>
                             }
                         }

--- a/src/app/pages/product-details/product-details.component.html
+++ b/src/app/pages/product-details/product-details.component.html
@@ -248,7 +248,7 @@
                                     <div class="bg-blue-500 rounded-t-lg w-full">
                                         <h5 class="flex justify-center mb-2 p-6 text-2xl font-bold tracking-tight text-gray-900">{{ 'SHOPPING_CART._free' | translate }}</h5>
                                     </div>
-                                    <p class="flex justify-center mb-2 font-normal text-gray-700">{{ 'SHOPPING_CART._free_desc' | translate }}</p>
+                                    <p class="flex justify-center mb-2 p-4 font-normal text-gray-700">{{ 'SHOPPING_CART._free_desc' | translate }}</p>
                                 </div>
                             </div>
                         }
@@ -263,7 +263,7 @@
                                     </div>
                                     <p class="flex justify-center font-normal text-gray-700 dark:text-white"> <b class="text-xl mr-2">{{price.price?.value}}</b> {{price.price?.unit}}</p>
                                     <p class="flex justify-center font-normal text-gray-700 dark:text-white">/{{price.recurringChargePeriodType}}</p>
-                                    <p class="flex justify-center mb-2 font-normal text-gray-700 dark:text-white">{{price.description}}</p>
+                                    <p class="flex justify-center mb-2 p-2 font-normal text-gray-700 dark:text-white">{{price.description}}</p>
                                 </div>
                             } @else if (price.priceType == 'usage') {
                                 <div class="max-w-sm bg-white border border-gray-200 dark:bg-secondary-200 dark:border-gray-800 rounded-lg shadow w-full">
@@ -272,15 +272,15 @@
                                     </div>
                                     <p class="flex justify-center font-normal text-gray-700 dark:text-white"> <b class="text-xl mr-2">{{price.price?.value}}</b> {{price.price?.unit}}</p>
                                     <p class="flex justify-center font-normal text-gray-700 dark:text-white">/{{price.unitOfMeasure?.units}}</p>
-                                    <p class="flex justify-center mb-2 font-normal text-gray-700 dark:text-white">{{price.description}}</p>
+                                    <p class="flex justify-center mb-2 p-4 font-normal text-gray-700 dark:text-white">{{price.description}}</p>
                                 </div>
                             } @else {
                                 <div class="max-w-sm bg-white border border-gray-200 dark:bg-secondary-200 dark:border-gray-800 rounded-lg shadow w-full">
                                     <div class="bg-blue-500 rounded-t-lg w-full">
-                                        <h5 class="flex justify-center mb-2 p-6 text-2xl font-bold tracking-tight text-gray-900">{{price.name}}</h5>
+                                        <h5 class="flex justify-center mb-4 p-6 text-2xl font-bold tracking-tight text-gray-900">{{price.name}}</h5>
                                     </div>
                                     <p class="flex justify-center font-normal text-gray-700 dark:text-white"> <b class="text-xl mr-2">{{price.price?.value}}</b> {{price.price?.unit}}</p>
-                                    <p class="flex justify-center mb-2 font-normal text-gray-700 dark:text-white">{{price.description}}</p>
+                                    <p class="flex justify-center mb-2 p-4 font-normal text-gray-700 dark:text-white">{{price.description}}</p>
                                 </div>
                             }
                         }
@@ -401,10 +401,12 @@
                             <div id="terms-markdown" class="line-clamp-5">
                                 <markdown class="text-lg font-normal text-gray-700 dark:text-gray-200 mb-4" [data]="productOff?.productOfferingTerm?.at(0)?.description"></markdown>
                             </div>
-                            @if(showTermsMore==false){
-                                <button class="mt-4 text-blue-500 focus:outline-none" (click)="toggleTermsReadMore()">Read more</button>
-                            } @else {
-                                <button class="mt-4 text-blue-500 focus:outline-none" (click)="toggleTermsReadMore()">Read less</button>
+                            @if(productOff?.productOfferingTerm?.at(0)?.description){
+                                @if(showTermsMore==false){
+                                    <button class="mt-4 text-blue-500 focus:outline-none" (click)="toggleTermsReadMore()">Read more</button>
+                                } @else {
+                                    <button class="mt-4 text-blue-500 focus:outline-none" (click)="toggleTermsReadMore()">Read less</button>
+                                }
                             }
                         </div>
                     </div>

--- a/src/app/pages/seller-offerings/offerings/seller-catalogs/create-catalog/create-catalog.component.html
+++ b/src/app/pages/seller-offerings/offerings/seller-catalogs/create-catalog/create-catalog.component.html
@@ -145,7 +145,7 @@
                             <div class="px-4 py-2 bg-white dark:bg-secondary-300 rounded-b-lg">
                                 <label for="editor" class="sr-only">Publish post</label>
                                 @if(showPreview){
-                                        <markdown class="text-gray-800 dark:text-gray-200" [data]="description"></markdown>
+                                        <markdown class="text-gray-800 dark:text-gray-200 text-wrap break-all" [data]="description"></markdown>
                                     
                                 }@else{
                                     <textarea id="editor" formControlName="description" rows="8" class="block w-full px-0 text-sm text-gray-800 dark:text-gray-200 bg-white dark:bg-secondary-300 border-0" placeholder="Add product description..." ></textarea>
@@ -173,7 +173,7 @@
                 <div class="m-8">
                     <div>
                         <label class="font-bold text-lg dark:text-white">{{ 'CREATE_CATALOG._name' | translate }}</label>
-                        <label class="mb-2 bg-gray-50 dark:bg-secondary-300 border border-gray-300 dark:border-secondary-200 dark:text-white text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                        <label class="mb-2 bg-gray-50 text-wrap break-all dark:bg-secondary-300 border border-gray-300 dark:border-secondary-200 dark:text-white text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
                             {{catalogToCreate?.name}}
                         </label>
                     </div>
@@ -194,7 +194,7 @@
                     @if(catalogToCreate?.description !=''){
                         <label class="font-bold text-lg dark:text-white">{{ 'CREATE_CATALOG._description' | translate }}</label>
                         <div class="px-4 py-2 bg-white rounded-lg p-4 mb-2 bg-gray-50 dark:bg-secondary-300 border border-gray-300 dark:border-secondary-200 dark:text-white text-gray-900">
-                            <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900" [data]="catalogToCreate?.description"></markdown>
+                            <markdown class="bg-gray-50 text-wrap break-all dark:bg-secondary-300 dark:text-white text-gray-900" [data]="catalogToCreate?.description"></markdown>
                         </div>
                     }
                     

--- a/src/app/pages/seller-offerings/offerings/seller-catalogs/seller-catalogs.component.html
+++ b/src/app/pages/seller-offerings/offerings/seller-catalogs/seller-catalogs.component.html
@@ -151,7 +151,7 @@
             <tbody>
                 @for (cat of catalogs; track cat.id) {
                     <tr class="border-b hover:bg-gray-200 dark:bg-secondary-300 dark:border-gray-700 dark:hover:bg-secondary-200">
-                        <td class="px-6 py-4">
+                        <td class="px-6 py-4 text-wrap break-all">
                             {{cat.name}}
                         </td>
                         <td class="px-6 py-4">

--- a/src/app/pages/seller-offerings/offerings/seller-catalogs/update-catalog/update-catalog.component.html
+++ b/src/app/pages/seller-offerings/offerings/seller-catalogs/update-catalog/update-catalog.component.html
@@ -223,7 +223,7 @@
                             <div class="px-4 py-2 bg-white dark:bg-secondary-300 rounded-b-lg">
                                 <label for="editor" class="sr-only">Publish post</label>
                                 @if(showPreview){
-                                        <markdown class="text-gray-800 dark:text-gray-200" [data]="description"></markdown>
+                                        <markdown class="text-gray-800 dark:text-gray-200 text-wrap break-all" [data]="description"></markdown>
                                     
                                 }@else{
                                     <textarea id="editor" formControlName="description" rows="8" class="block w-full px-0 text-sm text-gray-800 dark:text-gray-200 bg-white dark:bg-secondary-300 border-0" placeholder="Add product description..." ></textarea>
@@ -251,7 +251,7 @@
                 <div class="m-8">
                     <div>
                         <label class="font-bold text-lg dark:text-white">{{ 'UPDATE_CATALOG._name' | translate }}</label>
-                        <label class="mb-2 bg-gray-50 dark:bg-secondary-300 border border-gray-300 dark:border-secondary-200 dark:text-white text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                        <label class="mb-2 bg-gray-50 text-wrap break-all dark:bg-secondary-300 border border-gray-300 dark:border-secondary-200 dark:text-white text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
                             {{generalForm.value.name}}
                         </label>
                     </div>
@@ -272,7 +272,7 @@
                     @if(catalogToUpdate?.description !=''){
                         <label class="font-bold text-lg dark:text-white">{{ 'UPDATE_CATALOG._description' | translate }}</label>
                         <div class="px-4 py-2 bg-white rounded-lg p-4 mb-4 bg-gray-50 dark:bg-secondary-300 border border-gray-300 dark:border-secondary-200 dark:text-white text-gray-900">
-                            <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900" [data]="catalogToUpdate?.description"></markdown>
+                            <markdown class="bg-gray-50 text-wrap break-all dark:bg-secondary-300 dark:text-white text-gray-900" [data]="catalogToUpdate?.description"></markdown>
                         </div>
                     }
                     

--- a/src/app/pages/seller-offerings/offerings/seller-offer/create-offer/create-offer.component.html
+++ b/src/app/pages/seller-offerings/offerings/seller-offer/create-offer/create-offer.component.html
@@ -228,7 +228,7 @@
                         <div class="px-4 py-2 bg-white dark:bg-secondary-300 rounded-b-lg">
                             <label for="editor" class="sr-only">Publish post</label>
                             @if(showPreview){
-                                    <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900" [data]="description"></markdown>
+                                    <markdown class="bg-gray-50 text-wrap break-all dark:bg-secondary-300 dark:text-white text-gray-900" [data]="description"></markdown>
                                 
                             }@else{
                                 <textarea id="editor" formControlName="description" rows="8" class="block w-full px-0 text-sm text-gray-800 dark:text-gray-200 bg-white dark:bg-secondary-300 border-0" placeholder="Add product description..." ></textarea>
@@ -256,7 +256,7 @@
                     <label for="prod-brand" class="font-bold text-lg dark:text-white">{{ 'CREATE_OFFER._is_bundled' | translate }}</label>
                     <label class="inline-flex items-center me-5 cursor-pointer ml-4">
                         <input type="checkbox" (change)="toggleBundleCheck()" [checked]="bundleChecked" class="sr-only peer">
-                        <div class="relative w-11 h-6 bg-gray-200 dark:bg-gray-700 rounded-full peer peer-focus:ring-4 peer-focus:ring-primary-100 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary-100"></div>
+                        <div class="relative w-11 h-6 bg-gray-400 dark:bg-gray-700 rounded-full peer peer-focus:ring-4 peer-focus:ring-primary-100 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary-100"></div>
                     </label>
                 </div>
                 @if(bundleChecked){
@@ -769,7 +769,7 @@
                                     <div class="px-4 py-2 bg-white dark:bg-secondary-300 rounded-b-lg">
                                         <label for="editor" class="sr-only">Publish post</label>
                                         @if(showPreview){
-                                                <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900" [data]="licenseDescription"></markdown>
+                                                <markdown class="bg-gray-50 text-wrap break-all dark:bg-secondary-300 dark:text-white text-gray-900" [data]="licenseDescription"></markdown>
                                             
                                         }@else{
                                             <textarea id="editor" formControlName="description" rows="8" class="block w-full px-0 text-sm text-gray-800 dark:text-gray-200 bg-white dark:bg-secondary-300 border-0" placeholder="Add product description..." ></textarea>
@@ -990,10 +990,10 @@
                             <tbody>
                                 @for (price of createdPrices; track price.id) {
                                     <tr class="border-b hover:bg-gray-200 dark:bg-secondary-300 dark:border-gray-700 dark:hover:bg-secondary-200">
-                                        <td class="px-6 py-4">
+                                        <td class="px-6 py-4 max-w-1/6 text-wrap break-all">
                                             {{price.name}}
                                         </td>
-                                        <td class="hidden xl:table-cell px-6 py-4 line-clamp-1">
+                                        <td class="hidden xl:table-cell px-6 py-4 text-wrap break-all">
                                             {{price.description}}
                                         </td>
                                         <td class="hidden md:table-cell px-6 py-4">
@@ -1005,7 +1005,7 @@
                                         <td class="px-6 py-4">
                                             {{price.price?.taxIncludedAmount?.unit}}
                                         </td>
-                                        <td class="px-6 py-4">
+                                        <td class="px-6 py-4 inline-flex">
                                             <button (click)="removePrice(price)" type="button" class="text-white bg-red-600 hover:bg-red-700 focus:ring-4 focus:outline-none focus:ring-red-300 font-medium rounded-full text-sm p-1 text-center inline-flex items-center">
                                                 <svg class="w-4 h-4 text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
                                                     <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18 17.94 6M18 18 6.06 6"/>
@@ -1181,7 +1181,7 @@
                                     <div class="px-4 py-2 bg-white dark:bg-secondary-300 rounded-b-lg">
                                         <label for="editor" class="sr-only">Publish post</label>
                                         @if(showPreview){
-                                                <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900" [data]="priceDescription"></markdown>
+                                                <markdown class="bg-gray-50 text-wrap break-all dark:bg-secondary-300 dark:text-white text-gray-900" [data]="priceDescription"></markdown>
                                             
                                         }@else{
                                             <textarea id="editor" formControlName="description" rows="8" class="block w-full px-0 text-sm text-gray-800 border-0 dark:text-gray-200 bg-white dark:bg-secondary-300" placeholder="Add product description..." ></textarea>
@@ -1311,14 +1311,14 @@
                     <div class="mb-4 grid grid-cols-2 gap-4">
                         <div>
                             <label class="font-bold text-lg dark:text-white">{{ 'CREATE_OFFER._name' | translate }}</label>
-                            <label class="mb-2 bg-gray-50 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                            <label class="mb-2 bg-gray-50 text-wrap break-all dark:bg-secondary-300 dark:border-secondary-200 dark:text-white border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
                                 {{offerToCreate?.name}}
                             </label>
 
                         </div>
                         <div>
                             <label for="prod-version" class="font-bold text-lg dark:text-white">{{ 'CREATE_OFFER._version' | translate }}</label>
-                            <label class="mb-2 bg-gray-50 border border-gray-300 text-gray-900 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                            <label class="mb-2 bg-gray-50 text-wrap break-all border border-gray-300 text-gray-900 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
                                 {{offerToCreate?.version}}
                             </label>
                         </div>
@@ -1340,13 +1340,13 @@
                     @if(offerToCreate?.description !=''){
                         <label class="font-bold text-lg dark:text-white">{{ 'CREATE_OFFER._description' | translate }}</label>
                         <div class="px-4 py-2 bg-white rounded-lg p-4 mb-4 dark:bg-secondary-300 dark:text-white border dark:border-secondary-200">                                
-                            <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900" [data]="offerToCreate?.description"></markdown>
+                            <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900 text-wrap break-all" [data]="offerToCreate?.description"></markdown>
                         </div>
                     }
 
                     @if(offersBundle.length>0){
                         <label class="font-bold text-lg dark:text-white">{{ 'CREATE_OFFER._bundle' | translate }}</label>
-                        <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white m-4">                        
+                        <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white mb-4">                        
                             <table class="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-200">
                                 <thead class="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-secondary-200 dark:text-white">
                                     <tr>
@@ -1383,7 +1383,7 @@
                     }
                 
                     <label class="font-bold text-lg dark:text-white">{{ 'CREATE_OFFER._catalog' | translate }}</label>
-                    <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white m-4">                        
+                    <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white mb-4">                        
                     <table class="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-200">
                         <thead class="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-secondary-200 dark:text-white">
                             <tr>
@@ -1423,7 +1423,7 @@
                 </div>
                 @if(selectedCategories.length>0){
                     <h2 class="font-bold text-lg dark:text-white">{{ 'CREATE_OFFER._category' | translate }}</h2>
-                    <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white m-4">   
+                    <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white mb-4">   
                         <table class="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-200">
                             <thead class="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-secondary-200 dark:text-white">
                                 <tr>
@@ -1452,7 +1452,7 @@
                 }
                 @if(createdPrices.length>0){
                     <h2 class="font-bold text-lg dark:text-white">{{ 'CREATE_OFFER._price_plans' | translate }}</h2>
-                    <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white m-4">                        
+                    <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white mb-4">                        
                         <table class="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-200">
                             <thead class="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-secondary-200 dark:text-white">
                                 <tr>
@@ -1476,10 +1476,10 @@
                             <tbody>
                                 @for (price of createdPrices; track price.id) {
                                     <tr class="border-b hover:bg-gray-200 dark:bg-secondary-300 dark:border-gray-700 dark:hover:bg-secondary-200">
-                                        <td class="px-6 py-4">
+                                        <td class="px-6 py-4 max-w-1/6 text-wrap break-all">
                                             {{price.name}}
                                         </td>
-                                        <td class="hidden md:table-cell px-6 py-4 line-clamp-1">
+                                        <td class="hidden md:table-cell px-6 py-4 text-wrap break-all">
                                             {{price.description}}
                                         </td>
                                         <td class="hidden md:table-cell px-6 py-4">
@@ -1499,7 +1499,7 @@
                 }
                 @if(createdSLAs.length>0){
                     <h2 class="font-bold text-lg">{{ 'CREATE_OFFER._sla' | translate }}</h2>
-                    <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white m-4">                        
+                    <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white mb-4">                        
                         <table class="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-200">
                             <thead class="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-secondary-200 dark:text-white">
                                 <tr>
@@ -1542,12 +1542,12 @@
                     <h2 class="font-bold text-lg dark:text-white">{{ 'CREATE_OFFER._license' | translate }}</h2>
                     <div>
                         <label for="treatment" class="font-bold text-base dark:text-white">{{ 'CREATE_OFFER._treatment' | translate }}</label>
-                        <label class="mb-2 bg-gray-50 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                        <label class="mb-2 bg-gray-50 text-wrap break-all dark:bg-secondary-300 dark:border-secondary-200 dark:text-white border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
                             {{createdLicense.treatment}}
                         </label>
                         <label class="font-bold text-base dark:text-white">{{ 'CREATE_OFFER._description' | translate }}</label>
-                        <div class="px-4 py-2 bg-white dark:bg-secondary-300 border dark:border-secondary-200 dark:text-white rounded-lg p-4"> 
-                            <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900" [data]="createdLicense.description"></markdown>
+                        <div class="px-4 py-2 bg-gray-50 dark:bg-secondary-300 border border-gray-300 dark:border-secondary-200 dark:text-white rounded-lg p-4"> 
+                            <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900 text-wrap break-all" [data]="createdLicense.description"></markdown>
                         </div>
                     </div>
                 }
@@ -1716,7 +1716,7 @@
                         <div class="px-4 py-2 bg-white dark:bg-secondary-300 rounded-b-lg">
                             <label for="editor" class="sr-only">Publish post</label>
                             @if(showPreview){
-                                    <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900" [data]="priceDescription"></markdown>
+                                    <markdown class="bg-gray-50 text-wrap break-all dark:bg-secondary-300 dark:text-white text-gray-900" [data]="priceDescription"></markdown>
                                 
                             }@else{
                                 <textarea id="editor" formControlName="description" rows="8" class="block w-full px-0 text-sm text-gray-800 border-0 dark:text-gray-200 bg-white dark:bg-secondary-300" placeholder="Add product description..." ></textarea>

--- a/src/app/pages/seller-offerings/offerings/seller-offer/seller-offer.component.html
+++ b/src/app/pages/seller-offerings/offerings/seller-offer/seller-offer.component.html
@@ -154,7 +154,7 @@
                 <tbody>
                     @for (offer of offers; track offer.id) {
                         <tr class="border-b hover:bg-gray-200 dark:bg-secondary-300 dark:border-gray-700 dark:hover:bg-secondary-200">
-                            <td class="px-6 py-4">
+                            <td class="px-6 py-4 text-wrap break-all">
                                 {{offer.name}}
                             </td>
                             <td class="px-6 py-4">

--- a/src/app/pages/seller-offerings/offerings/seller-offer/update-offer/update-offer.component.html
+++ b/src/app/pages/seller-offerings/offerings/seller-offer/update-offer/update-offer.component.html
@@ -306,7 +306,7 @@
                         <div class="px-4 py-2 bg-white dark:bg-secondary-300 rounded-b-lg">
                             <label for="editor" class="sr-only">Publish post</label>
                             @if(showPreview){
-                                    <markdown class="text-gray-800 dark:text-gray-200" [data]="description"></markdown>
+                                    <markdown class="text-gray-800 dark:text-gray-200 text-wrap break-all" [data]="description"></markdown>
                                 
                             }@else{
                                 <textarea id="editor" formControlName="description" rows="8" class="block w-full px-0 text-sm text-gray-800 dark:text-gray-200 bg-white dark:bg-secondary-300 border-0" placeholder="Add product description..." ></textarea>
@@ -334,7 +334,7 @@
                     <label for="prod-brand" class="font-bold text-lg dark:text-white">{{ 'UPDATE_OFFER._is_bundled' | translate }}</label>
                     <label class="inline-flex items-center me-5 ml-4">
                         <input type="checkbox" value="" disabled class="sr-only peer">
-                        <div class="relative w-11 h-6 bg-gray-200 rounded-full peer peer-focus:ring-4 peer-focus:ring-primary-100 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary-100"></div>
+                        <div class="relative w-11 h-6 bg-gray-400 dark:bg-gray-700 rounded-full peer peer-focus:ring-4 peer-focus:ring-primary-100 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary-100"></div>
                     </label>
                 </div>
                 @if(bundleChecked){
@@ -808,7 +808,7 @@
                                     <div class="px-4 py-2 bg-white dark:bg-secondary-300 rounded-b-lg">
                                         <label for="editor" class="sr-only">Publish post</label>
                                         @if(showPreview){
-                                                <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900" [data]="licenseDescription"></markdown>
+                                                <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900 text-wrap break-all" [data]="licenseDescription"></markdown>
                                             
                                         }@else{
                                             <textarea id="editor" formControlName="description" rows="8" class="block w-full px-0 text-sm text-gray-800 dark:text-gray-200 bg-white dark:bg-secondary-300 border-0" placeholder="Add product description..." ></textarea>
@@ -1028,10 +1028,10 @@
                             <tbody>
                                 @for (price of createdPrices; track price.id) {
                                     <tr class="border-b hover:bg-gray-200 dark:bg-secondary-300 dark:border-gray-700 dark:hover:bg-secondary-200">
-                                        <td class="px-6 py-4">
+                                        <td class="px-6 py-4 max-w-1/6 text-wrap break-all">
                                             {{price.name}}
                                         </td>
-                                        <td class="hidden xl:table-cell px-6 py-4 line-clamp-1">
+                                        <td class="hidden xl:table-cell px-6 py-4 text-wrap break-all">
                                             {{price.description}}
                                         </td>
                                         <td class="hidden md:table-cell px-6 py-4">
@@ -1217,7 +1217,7 @@
                                     <div class="px-4 py-2 bg-white dark:bg-secondary-300 rounded-b-lg">
                                         <label for="editor" class="sr-only">Publish post</label>
                                         @if(showPreview){
-                                                <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900" [data]="priceDescription"></markdown>
+                                                <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900 text-wrap break-all" [data]="priceDescription"></markdown>
                                             
                                         }@else{
                                             <textarea id="editor" formControlName="description" rows="8" class="block w-full px-0 text-sm text-gray-800 border-0 dark:text-gray-200 bg-white dark:bg-secondary-300" placeholder="Add product description..." ></textarea>
@@ -1347,14 +1347,14 @@
                     <div class="mb-4 md:grid md:grid-cols-2 gap-4">
                         <div>
                             <label class="font-bold text-lg dark:text-white">{{ 'UPDATE_OFFER._name' | translate }}</label>
-                            <label class="mb-2 bg-gray-50 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                            <label class="mb-2 bg-gray-50 text-wrap break-all dark:bg-secondary-300 dark:border-secondary-200 dark:text-white border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
                                 {{offerToUpdate?.name}}
                             </label>
 
                         </div>
                         <div>
                             <label for="prod-version" class="font-bold text-lg dark:text-white">{{ 'UPDATE_OFFER._version' | translate }}</label>
-                            <label class="mb-2 bg-gray-50 border border-gray-300 text-gray-900 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                            <label class="mb-2 bg-gray-50 text-wrap break-all border border-gray-300 text-gray-900 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
                                 {{offerToUpdate?.version}}
                             </label>
                         </div>
@@ -1376,13 +1376,13 @@
                     @if(offerToUpdate?.description !=''){
                         <label class="font-bold text-lg dark:text-white">{{ 'UPDATE_OFFER._description' | translate }}</label>
                         <div class="px-4 py-2 bg-white rounded-lg p-4 mb-4 dark:bg-secondary-300 border dark:border-secondary-200 dark:text-white">                                
-                            <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900"  [data]="offerToUpdate?.description"></markdown>
+                            <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900 text-wrap break-all"  [data]="offerToUpdate?.description"></markdown>
                         </div>
                     }
 
                     @if(offersBundle.length>0){
                         <label class="font-bold text-lg dark:text-white">{{ 'UPDATE_OFFER._bundle' | translate }}</label>
-                        <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white m-4">                        
+                        <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white mb-4">                        
                             <table class="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-200">
                                 <thead class="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-secondary-200 dark:text-white">
                                     <tr>
@@ -1420,7 +1420,7 @@
                 
                 @if(selectedCategories.length>0){
                     <h2 class="font-bold text-lg  dark:text-white">{{ 'UPDATE_OFFER._category' | translate }}</h2>
-                    <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white m-4">   
+                    <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white mb-4">   
                         <table class="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-200">
                             <thead class="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-secondary-200 dark:text-white">
                                 <tr>
@@ -1449,7 +1449,7 @@
                 }
                 @if(createdPrices.length>0){
                     <h2 class="font-bold text-lg dark:text-white">{{ 'UPDATE_OFFER._price_plans' | translate }}</h2>
-                    <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white m-4">                        
+                    <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white mb-4">                        
                         <table class="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-200">
                             <thead class="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-secondary-200 dark:text-white">
                                 <tr>
@@ -1473,10 +1473,10 @@
                             <tbody>
                                 @for (price of createdPrices; track price.id) {
                                     <tr class="border-b hover:bg-gray-200 dark:bg-secondary-300 dark:border-gray-700 dark:hover:bg-secondary-200">
-                                        <td class="px-6 py-4">
+                                        <td class="px-6 py-4 max-w-1/6 text-wrap break-all">
                                             {{price.name}}
                                         </td>
-                                        <td class="hidden xl:table-cell px-6 py-4 line-clamp-1">
+                                        <td class="hidden xl:table-cell px-6 py-4 text-wrap break-all">
                                             {{price.description}}
                                         </td>
                                         <td class="hidden md:table-cell px-6 py-4">
@@ -1496,7 +1496,7 @@
                 }
                 @if(createdSLAs.length>0){
                     <h2 class="font-bold text-lg dark:text-white">{{ 'UPDATE_OFFER._sla' | translate }}</h2>
-                    <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white m-4">                        
+                    <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white mb-4">                        
                         <table class="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-200">
                             <thead class="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-secondary-200 dark:text-white">
                                 <tr>
@@ -1539,12 +1539,12 @@
                     <h2 class="font-bold text-lg dark:text-white">{{ 'UPDATE_OFFER._license' | translate }}</h2>
                     <div>
                         <label for="treatment" class="font-bold text-base dark:text-white">{{ 'UPDATE_OFFER._treatment' | translate }}</label>
-                        <label class="mb-2 bg-gray-50 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                        <label class="mb-2 bg-gray-50 text-wrap break-all dark:bg-secondary-300 dark:border-secondary-200 dark:text-white border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
                             {{createdLicense.treatment}}
                         </label>
                         <label class="font-bold text-base dark:text-white">{{ 'UPDATE_OFFER._description' | translate }}</label>
-                        <div class="px-4 py-2 bg-white dark:bg-secondary-300 border dark:border-secondary-200 dark:text-white rounded-lg p-4">                            
-                            <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900" [data]="createdLicense.description"></markdown>
+                        <div class="px-4 py-2 bg-gray-50 dark:bg-secondary-300 border border-gray-300 dark:border-secondary-200 dark:text-white rounded-lg p-4">                            
+                            <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900 text-wrap break-all" [data]="createdLicense.description"></markdown>
                         </div>
                     </div>
                 }
@@ -1714,7 +1714,7 @@
                         <div class="px-4 py-2 bg-white dark:bg-secondary-300 rounded-b-lg">
                             <label for="editor" class="sr-only">Publish post</label>
                             @if(showPreview){
-                                    <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900" [data]="priceDescription"></markdown>
+                                    <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900 text-wrap break-all" [data]="priceDescription"></markdown>
                                 
                             }@else{
                                 <textarea id="editor" formControlName="description" rows="8" class="block w-full px-0 text-sm text-gray-800 border-0 dark:text-gray-200 bg-white dark:bg-secondary-300" placeholder="Add product description..." ></textarea>

--- a/src/app/pages/seller-offerings/offerings/seller-product-spec/create-product-spec/create-product-spec.component.html
+++ b/src/app/pages/seller-offerings/offerings/seller-product-spec/create-product-spec/create-product-spec.component.html
@@ -322,20 +322,20 @@
                                             </td>
                                             <td class="hidden md:table-cell px-6 py-4">
                                                 @if(prod.lifecycleStatus == 'Active'){
-                                                    <span class="bg-blue-100 bg-secondary-300 text-blue-600 text-xs font-medium me-2 px-2.5 py-0.5 rounded border border-blue-400">{{prod.lifecycleStatus}}</span>
+                                                    <span class="bg-blue-100 dark:bg-secondary-300 text-blue-600 text-xs font-medium me-2 px-2.5 py-0.5 rounded border border-blue-400">{{prod.lifecycleStatus}}</span>
                                                 } @else if(prod.lifecycleStatus == 'Launched') {
-                                                    <span class="bg-blue-100 bg-secondary-300 text-green-500 text-xs font-medium me-2 px-2.5 py-0.5 rounded border border-green-500">{{prod.lifecycleStatus}}</span>
+                                                    <span class="bg-blue-100 dark:bg-secondary-300 text-green-500 text-xs font-medium me-2 px-2.5 py-0.5 rounded border border-green-500">{{prod.lifecycleStatus}}</span>
                                                 } @else if(prod.lifecycleStatus == 'Retired') {
-                                                    <span class="bg-blue-100 bg-secondary-300 text-yellow-500 text-xs font-medium me-2 px-2.5 py-0.5 rounded border border-yellow-500">{{prod.lifecycleStatus}}</span>
+                                                    <span class="bg-blue-100 dark:bg-secondary-300 text-yellow-500 text-xs font-medium me-2 px-2.5 py-0.5 rounded border border-yellow-500">{{prod.lifecycleStatus}}</span>
                                                 } @else if(prod.lifecycleStatus == 'Obsolete') {
-                                                    <span class="bg-blue-100 bg-secondary-300 text-red-500 text-xs font-medium me-2 px-2.5 py-0.5 rounded border border-red-500">{{prod.lifecycleStatus}}</span>
+                                                    <span class="bg-blue-100 dark:bg-secondary-300 text-red-500 text-xs font-medium me-2 px-2.5 py-0.5 rounded border border-red-500">{{prod.lifecycleStatus}}</span>
                                                 }
                                             </td>
                                             <td class="hidden md:table-cell px-6 py-4">
                                                 @if(prod.isBundle == false){
-                                                    <span class="bg-blue-100 bg-secondary-300 text-blue-600 text-xs font-medium me-2 px-2.5 py-0.5 rounded border border-blue-400">{{ 'CREATE_PROD_SPEC._simple' | translate }}</span>
+                                                    <span class="bg-blue-100 dark:bg-secondary-300 text-blue-600 text-xs font-medium me-2 px-2.5 py-0.5 rounded border border-blue-400">{{ 'CREATE_PROD_SPEC._simple' | translate }}</span>
                                                 } @else {
-                                                    <span class="bg-blue-100 bg-secondary-300 text-green-500 text-xs font-medium me-2 px-2.5 py-0.5 rounded border border-green-500">{{ 'CREATE_PROD_SPEC._bundle' | translate }}</span>
+                                                    <span class="bg-blue-100 dark:bg-secondary-300 text-green-500 text-xs font-medium me-2 px-2.5 py-0.5 rounded border border-green-500">{{ 'CREATE_PROD_SPEC._bundle' | translate }}</span>
                                                 }
                                             </td>
                                             <td class="hidden lg:table-cell px-6 py-4">

--- a/src/app/pages/seller-offerings/offerings/seller-product-spec/create-product-spec/create-product-spec.component.html
+++ b/src/app/pages/seller-offerings/offerings/seller-product-spec/create-product-spec/create-product-spec.component.html
@@ -240,7 +240,7 @@
                             <div class="px-4 py-2 bg-white dark:bg-secondary-300 rounded-b-lg">
                                 <label for="editor" class="sr-only">Publish post</label>
                                 @if(showPreview){
-                                        <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900" [data]="description"></markdown>
+                                        <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900 text-wrap break-all" [data]="description"></markdown>
                                     
                                 }@else{
                                     <textarea id="editor" formControlName="description" rows="8" class="block w-full px-0 text-sm text-gray-800 dark:text-gray-200 bg-white dark:bg-secondary-300 border-0" placeholder="Add product description..." ></textarea>
@@ -268,7 +268,7 @@
                         <label for="prod-brand" class="font-bold text-lg dark:text-white">{{ 'CREATE_PROD_SPEC._is_bundled' | translate }}</label>
                         <label class="inline-flex items-center me-5 cursor-pointer ml-4">
                             <input type="checkbox" (change)="toggleBundleCheck()" [checked]="bundleChecked" class="sr-only peer">
-                            <div class="relative w-11 h-6 bg-gray-200 rounded-full peer peer-focus:ring-4 peer-focus:ring-primary-100 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary-100"></div>
+                            <div class="relative w-11 h-6 bg-gray-400 dark:bg-gray-700 rounded-full peer peer-focus:ring-4 peer-focus:ring-primary-100 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary-100"></div>
                         </label>
                     </div>
                     @if(bundleChecked){
@@ -514,13 +514,13 @@
                                 <tbody>
                                     @for (prod of prodChars; track prod;) {
                                         <tr class="border-b hover:bg-gray-200 dark:bg-secondary-300 dark:border-gray-700 dark:hover:bg-secondary-200">
-                                            <td class="px-6 py-4">
+                                            <td class="px-6 py-4 max-w-1/6 text-wrap break-all">
                                                 {{prod.name}}
                                             </td>
-                                            <td class="hidden lg:table-cell px-6 py-4">
+                                            <td class="hidden lg:table-cell px-6 py-4 text-wrap break-all">
                                                 {{prod.description}}                                       
                                             </td>
-                                            <td class="px-6 py-4">
+                                            <td class="px-6 py-4 text-wrap break-all">
                                                 @for (char of prod.productSpecCharacteristicValue; track char;) {
                                                     @if(char.value){
                                                         {{char.value}} {{char?.unitOfMeasure}},
@@ -740,7 +740,7 @@
                             <tbody>
                                 @for (res of resourceSpecs; track res.id) {
                                     <tr class="border-b hover:bg-gray-200 dark:bg-secondary-300 dark:border-gray-700 dark:hover:bg-secondary-200">
-                                        <td class="px-6 py-4">
+                                        <td class="px-6 py-4 text-wrap break-all">
                                             {{res.name}}
                                         </td>
                                         <td class="hidden md:table-cell px-6 py-4">
@@ -840,7 +840,7 @@
                             <tbody>
                                 @for (serv of serviceSpecs; track serv.id) {
                                     <tr class="border-b hover:bg-gray-200 dark:bg-secondary-300 dark:border-gray-700 dark:hover:bg-secondary-200">
-                                        <td class="px-6 py-4">
+                                        <td class="px-6 py-4 text-wrap break-all">
                                             {{serv.name}}
                                         </td>
                                         <td class="hidden md:table-cell px-6 py-4">
@@ -968,10 +968,10 @@
                                 <tbody>
                                     @for (att of prodAttachments; track att) {
                                         <tr class="border-b hover:bg-gray-200 dark:bg-secondary-300 dark:border-gray-700 dark:hover:bg-secondary-200">
-                                            <td class="px-6 py-4">
+                                            <td class="px-6 py-4 text-wrap break-all">
                                                 {{att.name}}
                                             </td>
-                                            <td class="px-6 py-4">
+                                            <td class="px-6 py-4 text-wrap break-all">
                                                 {{att.url}} 
                                             </td>
                                             <td class="px-6 py-4">
@@ -1096,7 +1096,7 @@
                                                 <td class="px-6 py-4">
                                                     {{rel.relationshipType}}
                                                 </td>
-                                                <td class="px-6 py-4">
+                                                <td class="px-6 py-4 text-wrap break-all">
                                                     {{rel.productSpec.name}}
                                                 </td>
                                                 <td class="hidden md:table-cell px-6 py-4">
@@ -1249,22 +1249,22 @@
                         <div class="mb-4 md:grid md:grid-cols-2 gap-4">
                             <div>
                                 <label class="font-bold text-lg dark:text-white">{{ 'CREATE_PROD_SPEC._product_name' | translate }}</label>
-                                <label class="mb-2 bg-gray-50 border border-gray-300 text-gray-900 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                                <label class="mb-2 bg-gray-50 text-wrap break-all border border-gray-300 text-gray-900 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
                                     {{productSpecToCreate?.name}}
                                 </label>
                                 <label for="prod-version" class="font-bold text-lg dark:text-white">{{ 'CREATE_PROD_SPEC._product_version' | translate }}</label>
-                                <label class="mb-2 bg-gray-50 border border-gray-300 text-gray-900 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                                <label class="mb-2 bg-gray-50 text-wrap break-all border border-gray-300 text-gray-900 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
                                     {{productSpecToCreate?.version}}
                                 </label>
                             </div>
                             <div>
                                 <label class="font-bold text-lg dark:text-white">{{ 'CREATE_PROD_SPEC._product_brand' | translate }}</label>
-                                <label class="mb-2 bg-gray-50 border border-gray-300 text-gray-900 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" >
+                                <label class="mb-2 bg-gray-50 text-wrap break-all border border-gray-300 text-gray-900 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" >
                                     {{productSpecToCreate?.brand}}
                                 </label>
                                 @if(productSpecToCreate?.productNumber!=''){
                                 <label class="font-bold text-lg dark:text-white">{{ 'CREATE_PROD_SPEC._id_number' | translate }}</label>
-                                <label class="mb-2 bg-gray-50 border border-gray-300 text-gray-900 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                                <label class="mb-2 bg-gray-50 text-wrap break-all border border-gray-300 text-gray-900 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
                                     {{productSpecToCreate?.productNumber}}
                                 </label>
                                 }
@@ -1287,7 +1287,7 @@
                         @if(productSpecToCreate?.description !=''){
                             <label class="font-bold text-lg dark:text-white">{{ 'UPDATE_PROD_SPEC._product_description' | translate }}</label>
                             <div class="px-4 py-2 bg-white rounded-lg p-4 dark:bg-secondary-300 border dark:border-secondary-200"> 
-                                <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900" [data]="productSpecToCreate?.description"></markdown>
+                                <markdown class="bg-gray-50 text-wrap break-all dark:bg-secondary-300 dark:text-white text-gray-900" [data]="productSpecToCreate?.description"></markdown>
                             </div>
                         }
 
@@ -1300,7 +1300,7 @@
 
                         @if(prodSpecsBundle.length>0){
                             <label class="font-bold text-lg dark:text-white">{{ 'CREATE_PROD_SPEC._bundle' | translate }}</label>
-                            <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white m-4">                        
+                            <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white mb-4">                        
                                 <table class="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-200">
                                     <thead class="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-secondary-200 dark:text-white">
                                         <tr>
@@ -1315,7 +1315,7 @@
                                     <tbody>
                                         @for (bun of prodSpecsBundle; track bun) {
                                             <tr class="border-b hover:bg-gray-200 dark:bg-secondary-300 dark:border-gray-700 dark:hover:bg-secondary-200">
-                                                <td class="px-6 py-4">
+                                                <td class="px-6 py-4 text-wrap break-all">
                                                     {{bun.name}}
                                                 </td>
                                                 <td class="px-6 py-4">
@@ -1338,7 +1338,7 @@
                         
                         @if(prodChars.length>0){
                             <label class="font-bold text-lg dark:text-white">{{ 'CREATE_PROD_SPEC._chars' | translate }}</label>
-                            <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white m-4">                        
+                            <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white mb-4">                        
                                 <table class="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-200">
                                     <thead class="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-secondary-200 dark:text-white">
                                         <tr>
@@ -1356,13 +1356,13 @@
                                     <tbody>
                                         @for (prod of productSpecToCreate?.productSpecCharacteristic; track prod;) {
                                             <tr class="border-b hover:bg-gray-200 dark:bg-secondary-300 dark:border-gray-700 dark:hover:bg-secondary-200">
-                                                <td class="px-6 py-4">
+                                                <td class="px-6 py-4 text-wrap break-all">
                                                     {{prod.name}}
                                                 </td>
-                                                <td class="hidden lg:table-cell px-6 py-4">
+                                                <td class="hidden lg:table-cell px-6 py-4 text-wrap break-all">
                                                     {{prod.description}}                                       
                                                 </td>
-                                                <td class="px-6 py-4">
+                                                <td class="px-6 py-4 text-wrap break-all">
                                                     @for (char of prod.productSpecCharacteristicValue; track char;) {
                                                         @if(char.value){
                                                             {{char.value}} {{char?.unitOfMeasure}},
@@ -1380,7 +1380,7 @@
 
                         @if(selectedResourceSpecs.length>0){
                             <label class="font-bold text-lg dark:text-white">{{ 'CREATE_PROD_SPEC._resource' | translate }}</label>
-                            <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white m-4">                        
+                            <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white mb-4">                        
                                 <table class="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-200">
                                     <thead class="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-secondary-200 dark:text-white">
                                         <tr>
@@ -1392,7 +1392,7 @@
                                     <tbody>
                                         @for (res of selectedResourceSpecs; track res) {
                                             <tr class="border-b hover:bg-gray-200 dark:bg-secondary-300 dark:border-gray-700 dark:hover:bg-secondary-200">
-                                                <td class="px-6 py-4">
+                                                <td class="px-6 py-4 text-wrap break-all">
                                                     {{res.name}}
                                                 </td>
                                             </tr>
@@ -1404,7 +1404,7 @@
 
                         @if(selectedServiceSpecs.length>0){
                             <label class="font-bold text-lg dark:text-white">{{ 'CREATE_PROD_SPEC._service' | translate }}</label>
-                            <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white m-4">                        
+                            <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white mb-4">                        
                                 <table class="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-200">
                                     <thead class="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-secondary-200 dark:text-white">
                                         <tr>
@@ -1416,7 +1416,7 @@
                                     <tbody>
                                         @for (serv of selectedServiceSpecs; track serv) {
                                             <tr class="border-b hover:bg-gray-200 dark:bg-secondary-300 dark:border-gray-700 dark:hover:bg-secondary-200">
-                                                <td class="px-6 py-4">
+                                                <td class="px-6 py-4 text-wrap break-all">
                                                     {{serv.name}}
                                                 </td>
                                             </tr>
@@ -1428,7 +1428,7 @@
 
                         @if(prodAttachments.length>0){
                             <label class="font-bold text-lg dark:text-white">{{ 'CREATE_PROD_SPEC._attachments' | translate }}</label>
-                            <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white m-4">                        
+                            <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white mb-4">                        
                                 <table class="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-200">
                                     <thead class="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-secondary-200 dark:text-white">
                                         <tr>
@@ -1443,10 +1443,10 @@
                                     <tbody>
                                         @for (att of productSpecToCreate?.attachment; track att) {
                                             <tr class="border-b hover:bg-gray-200 dark:bg-secondary-300 dark:border-gray-700 dark:hover:bg-secondary-200">
-                                                <td class="px-6 py-4">
+                                                <td class="px-6 py-4 text-wrap break-all">
                                                     {{att.name}}
                                                 </td>
-                                                <td class="px-6 py-4">
+                                                <td class="px-6 py-4 text-wrap break-all">
                                                     {{att.url}} 
                                                 </td>
                                             </tr>
@@ -1458,7 +1458,7 @@
 
                         @if(prodRelationships.length>0){
                             <label class="font-bold text-lg dark:text-white">{{ 'CREATE_PROD_SPEC._relationships' | translate }}</label>
-                            <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white m-4">                        
+                            <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white mb-4">                        
                                 <table class="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-200">
                                     <thead class="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-secondary-200 dark:text-white">
                                         <tr>
@@ -1482,7 +1482,7 @@
                                                 <td class="px-6 py-4">
                                                     {{rel.relationshipType}}
                                                 </td>
-                                                <td class="px-6 py-4">
+                                                <td class="px-6 py-4 text-wrap break-all">
                                                     {{rel.productSpec.name}}
                                                 </td>
                                                 <td class="hidden md:table-cell px-6 py-4">

--- a/src/app/pages/seller-offerings/offerings/seller-product-spec/seller-product-spec.component.html
+++ b/src/app/pages/seller-offerings/offerings/seller-product-spec/seller-product-spec.component.html
@@ -155,7 +155,7 @@
             <tbody>
                 @for (prod of prodSpecs; track prod.id) {
                     <tr class="border-b hover:bg-gray-200 dark:bg-secondary-300 dark:border-gray-700 dark:hover:bg-secondary-200">
-                        <td class="px-6 py-4">
+                        <td class="px-6 py-4 text-wrap break-all">
                             {{prod.name}}
                         </td>
                         <td class="px-6 py-4">

--- a/src/app/pages/seller-offerings/offerings/seller-product-spec/update-product-spec/update-product-spec.component.html
+++ b/src/app/pages/seller-offerings/offerings/seller-product-spec/update-product-spec/update-product-spec.component.html
@@ -445,7 +445,6 @@
                 }
                 @if(showCompliance){
                     <h2 class="text-3xl font-bold text-primary-100 ml-4 dark:text-white">{{ 'UPDATE_PROD_SPEC._comp_profile' | translate }}</h2>
-
                     @if(availableISOS.length>0){
                         <button id="dropdownButtonISO" (click)="buttonISOClicked=!buttonISOClicked" data-dropdown-toggle="dropdownISO" class="text-white w-full m-4 bg-primary-100 hover:bg-primary-50 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center inline-flex items-center justify-between" type="button">
                             {{ 'UPDATE_PROD_SPEC._add_comp' | translate }}
@@ -475,15 +474,33 @@
                             </div>
                         }
                     }
-
-                    <div class="flex w-full justify-items-end justify-end ml-4">
-                        <button type="button" (click)="verifyCredential();"  class="flex text-white justify-end bg-primary-100 hover:bg-primary-50 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center inline-flex items-center">
+                    <div class="flex w-full justify-items-end justify-end align-items-middle ml-4 h-fit">
+                        <button type="button" (click)="verifyCredential();"
+                        class="flex text-white justify-end bg-primary-100 hover:bg-primary-50 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center inline-flex items-center">
                             {{ 'UPDATE_PROD_SPEC._verify' | translate }}
                             <svg class="w-4 h-4 text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
                                 <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 11.917 9.724 16.5 19 7.5"/>
                             </svg>
                         </button>
+
+                        <div class="ml-4 flex">
+                            <svg data-popover-target="popover-default" class="flex self-center w-6 h-6 text-primary-100" clip-rule="evenodd" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+                                <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 11h2v5m-2 0h4m-2.592-8.5h.01M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/>
+                            </svg>
+                        </div>                          
                     </div>
+                    <div data-popover id="popover-default" role="tooltip" class="absolute z-10 invisible inline-block w-64 text-sm text-gray-500 transition-opacity duration-300 bg-white border border-gray-200 rounded-lg shadow-sm opacity-0 dark:text-gray-400 dark:border-gray-600 dark:bg-gray-800">
+                        <div class="px-3 py-2 bg-gray-100 border-b border-gray-200 rounded-t-lg dark:border-gray-600 dark:bg-gray-700">
+                            <h3 class="font-semibold text-gray-900 dark:text-white">{{ 'UPDATE_PROD_SPEC._how_to_verify' | translate }}</h3>
+                        </div>
+                        <div class="px-3 py-2 inline-block">
+                            <p class="inline-block">{{ 'UPDATE_PROD_SPEC._verify_text' | translate }}
+                                <a href="{{DOME_TRUST_LINK}}" target="_blank" class="font-medium text-blue-600 dark:text-blue-500 hover:underline">
+                                    {{ 'UPDATE_PROD_SPEC._dome_trust' | translate }}.</a>
+                            </p>
+                        </div>
+                        <div data-popper-arrow></div>
+                    </div>                 
                     
                     <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white dark:bg-secondary-300 m-4">                        
                         <table class="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-200">

--- a/src/app/pages/seller-offerings/offerings/seller-product-spec/update-product-spec/update-product-spec.component.html
+++ b/src/app/pages/seller-offerings/offerings/seller-product-spec/update-product-spec/update-product-spec.component.html
@@ -315,7 +315,7 @@
                             <div class="px-4 py-2 bg-white dark:bg-secondary-300 rounded-lg p-4">
                                 <label for="editor" class="sr-only">Publish post</label>
                                 @if(showPreview){
-                                        <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900" [data]="description"></markdown>
+                                        <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900 text-wrap break-all" [data]="description"></markdown>
                                     
                                 }@else{
                                     <textarea id="editor" formControlName="description" rows="8" class="block w-full px-0 text-sm text-gray-800 dark:text-gray-200 bg-white dark:bg-secondary-300 border-0" placeholder="Add product description..." ></textarea>
@@ -343,7 +343,7 @@
                         <label for="prod-brand" class="font-bold text-lg dark:text-white">{{ 'UPDATE_PROD_SPEC._is_bundled' | translate }}</label>
                         <label class="inline-flex items-center me-5 ml-4">
                             <input type="checkbox" disabled [checked]="bundleChecked" value="" class="sr-only peer">
-                            <div class="relative w-11 h-6 bg-gray-200 rounded-full peer peer-focus:ring-4 peer-focus:ring-primary-100 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary-100"></div>
+                            <div class="relative w-11 h-6 bg-gray-400 dark:bg-gray-700 rounded-full peer peer-focus:ring-4 peer-focus:ring-primary-100 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary-100"></div>
                         </label>
                     </div>
                     @if(bundleChecked){
@@ -617,13 +617,13 @@
                                 <tbody>
                                     @for (prod of prodChars; track prod;) {
                                         <tr class="border-b hover:bg-gray-200 dark:bg-secondary-300 dark:border-gray-700 dark:hover:bg-secondary-200">
-                                            <td class="px-6 py-4">
+                                            <td class="px-6 py-4 max-w-1/6 text-wrap break-all">
                                                 {{prod.name}}
                                             </td>
-                                            <td class="hidden lg:table-cell px-6 py-4">
+                                            <td class="hidden lg:table-cell px-6 py-4 text-wrap break-all">
                                                 {{prod.description}}                                       
                                             </td>
-                                            <td class="px-6 py-4">
+                                            <td class="px-6 py-4 text-wrap break-all">
                                                 @for (char of prod.productSpecCharacteristicValue; track char;) {
                                                     @if(char.value){
                                                         {{char.value}} {{char?.unitOfMeasure}},
@@ -843,7 +843,7 @@
                             <tbody>
                                 @for (res of resourceSpecs; track res.id) {
                                     <tr class="border-b hover:bg-gray-200 dark:bg-secondary-300 dark:border-gray-700 dark:hover:bg-secondary-200">
-                                        <td class="px-6 py-4">
+                                        <td class="px-6 py-4 text-wrap break-all">
                                             {{res.name}}
                                         </td>
                                         <td class="hidden md:table-cell px-6 py-4">
@@ -1071,10 +1071,10 @@
                                 <tbody>
                                     @for (att of prodAttachments; track att) {
                                         <tr class="border-b hover:bg-gray-200 dark:bg-secondary-300 dark:border-gray-700 dark:hover:bg-secondary-200">
-                                            <td class="px-6 py-4">
+                                            <td class="px-6 py-4 max-w-1/6 text-wrap break-all">
                                                 {{att.name}}
                                             </td>
-                                            <td class="px-6 py-4">
+                                            <td class="px-6 py-4 text-wrap break-all">
                                                 {{att.url}} 
                                             </td>
                                             <td class="px-6 py-4">
@@ -1199,7 +1199,7 @@
                                                 <td class="px-6 py-4">
                                                     {{rel.relationshipType}}
                                                 </td>
-                                                <td class="px-6 py-4">
+                                                <td class="px-6 py-4 text-wrap break-all">
                                                     {{rel.productSpec.name}}
                                                 </td>
                                                 <td class="hidden md:table-cell px-6 py-4">
@@ -1352,22 +1352,22 @@
                         <div class="mb-4 md:grid md:grid-cols-2 gap-4">
                             <div>
                                 <label class="font-bold text-lg dark:text-white">{{ 'UPDATE_PROD_SPEC._product_name' | translate }}</label>
-                                <label class="mb-2 bg-gray-50 border border-gray-300 text-gray-900 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                                <label class="mb-2 bg-gray-50 text-wrap break-all border border-gray-300 text-gray-900 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
                                     {{productSpecToUpdate?.name}}
                                 </label>
                                 <label for="prod-version" class="font-bold text-lg dark:text-white">{{ 'UPDATE_PROD_SPEC._product_version' | translate }}</label>
-                                <label class="mb-2 bg-gray-50 border border-gray-300 text-gray-900 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                                <label class="mb-2 bg-gray-50 text-wrap break-all border border-gray-300 text-gray-900 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
                                     {{productSpecToUpdate?.version}}
                                 </label>
                             </div>
                             <div>
                                 <label class="font-bold text-lg dark:text-white">{{ 'UPDATE_PROD_SPEC._product_brand' | translate }}</label>
-                                <label class="mb-2 bg-gray-50 border border-gray-300 text-gray-900 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" >
+                                <label class="mb-2 bg-gray-50 text-wrap break-all border border-gray-300 text-gray-900 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" >
                                     {{productSpecToUpdate?.brand}}
                                 </label>
                                 @if(productSpecToUpdate?.productNumber!=''){
                                 <label class="font-bold text-lg dark:text-white">{{ 'UPDATE_PROD_SPEC._id_number' | translate }}</label>
-                                <label class="mb-2 bg-gray-50 border border-gray-300 text-gray-900 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                                <label class="mb-2 bg-gray-50 text-wrap break-all border border-gray-300 text-gray-900 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
                                     {{productSpecToUpdate?.productNumber}}
                                 </label>
                                 }
@@ -1390,7 +1390,7 @@
                         @if(productSpecToUpdate?.description !=''){
                             <label class="font-bold text-lg dark:text-white">{{ 'UPDATE_PROD_SPEC._product_description' | translate }}</label>
                             <div class="px-4 py-2 bg-white dark:bg-secondary-300 border dark:border-secondary-200 rounded-lg p-4 mb-4">                                
-                                <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900" [data]="productSpecToUpdate?.description"></markdown>
+                                <markdown class="bg-gray-50 text-wrap break-all dark:bg-secondary-300 dark:text-white text-gray-900" [data]="productSpecToUpdate?.description"></markdown>
                             </div>
                         }
 
@@ -1403,7 +1403,7 @@
 
                         @if(prodSpecsBundle.length>0){
                             <label class="font-bold text-lg dark:text-white">{{ 'UPDATE_PROD_SPEC._bundle' | translate }}</label>
-                            <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white m-4">                        
+                            <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white mb-4">                        
                                 <table class="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-200">
                                     <thead class="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-secondary-200 dark:text-white">
                                         <tr>
@@ -1418,7 +1418,7 @@
                                     <tbody>
                                         @for (bun of prodSpecsBundle; track bun) {
                                             <tr class="border-b hover:bg-gray-200 dark:bg-secondary-300 dark:border-gray-700 dark:hover:bg-secondary-200">
-                                                <td class="px-6 py-4">
+                                                <td class="px-6 py-4 text-wrap break-all">
                                                     {{bun.name}}
                                                 </td>
                                                 <td class="px-6 py-4">
@@ -1441,7 +1441,7 @@
                         
                         @if(prodChars.length>0){
                             <label class="font-bold text-lg dark:text-white">{{ 'UPDATE_PROD_SPEC._chars' | translate }}</label>
-                            <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white m-4">                        
+                            <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white mb-4">                        
                                 <table class="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-200">
                                     <thead class="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-secondary-200 dark:text-white">
                                         <tr>
@@ -1459,13 +1459,13 @@
                                     <tbody>
                                         @for (prod of productSpecToUpdate?.productSpecCharacteristic; track prod;) {
                                             <tr class="border-b hover:bg-gray-200 dark:bg-secondary-300 dark:border-gray-700 dark:hover:bg-secondary-200">
-                                                <td class="px-6 py-4">
+                                                <td class="px-6 py-4 max-w-1/6 text-wrap break-all">
                                                     {{prod.name}}
                                                 </td>
-                                                <td class="hidden lg:table-cell px-6 py-4">
+                                                <td class="hidden lg:table-cell px-6 py-4 text-wrap break-all">
                                                     {{prod.description}}                                       
                                                 </td>
-                                                <td class="px-6 py-4">
+                                                <td class="px-6 py-4 text-wrap break-all">
                                                     @for (char of prod.productSpecCharacteristicValue; track char;) {
                                                         @if(char.value){
                                                             {{char.value}} {{char?.unitOfMeasure}},
@@ -1483,7 +1483,7 @@
 
                         @if(selectedResourceSpecs.length>0){
                             <label class="font-bold text-lg dark:text-white">{{ 'UPDATE_PROD_SPEC._resource' | translate }}</label>
-                            <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white m-4">                        
+                            <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white mb-4">                        
                                 <table class="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-200">
                                     <thead class="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-secondary-200 dark:text-white">
                                         <tr>
@@ -1495,7 +1495,7 @@
                                     <tbody>
                                         @for (res of selectedResourceSpecs; track res) {
                                             <tr class="border-b hover:bg-gray-200 dark:bg-secondary-300 dark:border-gray-700 dark:hover:bg-secondary-200">
-                                                <td class="px-6 py-4">
+                                                <td class="px-6 py-4 text-wrap break-all">
                                                     {{res.name}}
                                                 </td>
                                             </tr>
@@ -1507,7 +1507,7 @@
 
                         @if(selectedServiceSpecs.length>0){
                             <label class="font-bold text-lg dark:text-white">{{ 'UPDATE_PROD_SPEC._service' | translate }}</label>
-                            <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white m-4">                        
+                            <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white mb-4">                        
                                 <table class="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-200">
                                     <thead class="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-secondary-200 dark:text-white">
                                         <tr>
@@ -1519,7 +1519,7 @@
                                     <tbody>
                                         @for (serv of selectedServiceSpecs; track serv) {
                                             <tr class="border-b hover:bg-gray-200 dark:bg-secondary-300 dark:border-gray-700 dark:hover:bg-secondary-200">
-                                                <td class="px-6 py-4">
+                                                <td class="px-6 py-4 text-wrap break-all">
                                                     {{serv.name}}
                                                 </td>
                                             </tr>
@@ -1531,7 +1531,7 @@
 
                         @if(prodAttachments.length>0){
                             <label class="font-bold text-lg dark:text-white">{{ 'UPDATE_PROD_SPEC._attachments' | translate }}</label>
-                            <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white m-4">                        
+                            <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white mb-4">                        
                                 <table class="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-200">
                                     <thead class="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-secondary-200 dark:text-white">
                                         <tr>
@@ -1546,10 +1546,10 @@
                                     <tbody>
                                         @for (att of productSpecToUpdate?.attachment; track att) {
                                             <tr class="border-b hover:bg-gray-200 dark:bg-secondary-300 dark:border-gray-700 dark:hover:bg-secondary-200">
-                                                <td class="px-6 py-4">
+                                                <td class="px-6 py-4 max-w-1/6 text-wrap break-all">
                                                     {{att.name}}
                                                 </td>
-                                                <td class="px-6 py-4">
+                                                <td class="px-6 py-4 text-wrap break-all">
                                                     {{att.url}} 
                                                 </td>
                                             </tr>
@@ -1561,7 +1561,7 @@
 
                         @if(prodRelationships.length>0){
                             <label class="font-bold text-lg dark:text-white">{{ 'UPDATE_PROD_SPEC._relationships' | translate }}</label>
-                            <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white m-4">                        
+                            <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white mb-4">                        
                                 <table class="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-200">
                                     <thead class="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-secondary-200 dark:text-white">
                                         <tr>
@@ -1585,7 +1585,7 @@
                                                 <td class="px-6 py-4">
                                                     {{rel.relationshipType}}
                                                 </td>
-                                                <td class="px-6 py-4">
+                                                <td class="px-6 py-4 text-wrap break-all">
                                                     {{rel.productSpec.name}}
                                                 </td>
                                                 <td class="hidden md:table-cell px-6 py-4">

--- a/src/app/pages/seller-offerings/offerings/seller-product-spec/update-product-spec/update-product-spec.component.ts
+++ b/src/app/pages/seller-offerings/offerings/seller-product-spec/update-product-spec/update-product-spec.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectorRef, HostListener, ElementRef, ViewChild, Input } from '@angular/core';
+import { Component, OnInit, ChangeDetectorRef, HostListener, ElementRef, ViewChild, Input, AfterViewInit } from '@angular/core';
 import { Router } from '@angular/router';
 import {components} from "src/app/models/product-catalog";
 import { environment } from 'src/environments/environment';
@@ -33,13 +33,14 @@ type AttachmentRefOrValue = components["schemas"]["AttachmentRefOrValue"];
   templateUrl: './update-product-spec.component.html',
   styleUrl: './update-product-spec.component.css'
 })
-export class UpdateProductSpecComponent implements OnInit{
+export class UpdateProductSpecComponent implements OnInit {
   @Input() prod: any;
 
   //PAGE SIZES:
   PROD_SPEC_LIMIT: number = environment.PROD_SPEC_LIMIT;
   SERV_SPEC_LIMIT: number = environment.SERV_SPEC_LIMIT;
   RES_SPEC_LIMIT: number = environment.RES_SPEC_LIMIT;
+  DOME_TRUST_LINK: string = environment.DOME_TRUST_LINK
 
   //CONTROL VARIABLES:
   showGeneral:boolean=true;
@@ -195,6 +196,7 @@ export class UpdateProductSpecComponent implements OnInit{
     this.initPartyInfo();
     console.log(this.prod)
     this.populateProductInfo();
+    initFlowbite();
   }
 
   initPartyInfo(){
@@ -365,6 +367,7 @@ export class UpdateProductSpecComponent implements OnInit{
     this.showRelationships=false;
     this.showSummary=false;
     this.showPreview=false;
+    initFlowbite();
   }
 
   toggleBundle(){
@@ -379,6 +382,7 @@ export class UpdateProductSpecComponent implements OnInit{
     this.showRelationships=false;
     this.showSummary=false;
     this.showPreview=false;
+    initFlowbite();
   }
 
   toggleBundleCheck(){
@@ -459,6 +463,9 @@ export class UpdateProductSpecComponent implements OnInit{
     this.showRelationships=false;
     this.showSummary=false;
     this.showPreview=false;
+    setTimeout(() => {        
+      initFlowbite();   
+    }, 100);
   }
 
   addISO(iso:any){
@@ -660,6 +667,7 @@ export class UpdateProductSpecComponent implements OnInit{
     this.numberCharSelected=false;
     this.rangeCharSelected=false;
     this.showPreview=false;
+    initFlowbite();
   }
 
   toggleResource(){
@@ -678,6 +686,7 @@ export class UpdateProductSpecComponent implements OnInit{
     this.showRelationships=false;
     this.showSummary=false;
     this.showPreview=false;
+    initFlowbite();
   }
 
   getResSpecs(){    
@@ -749,6 +758,7 @@ export class UpdateProductSpecComponent implements OnInit{
     this.showRelationships=false;
     this.showSummary=false;
     this.showPreview=false;
+    initFlowbite();
   }
 
   getServSpecs(){    
@@ -816,6 +826,7 @@ export class UpdateProductSpecComponent implements OnInit{
     this.showRelationships=false;
     this.showSummary=false;
     this.showPreview=false;
+    initFlowbite();
   }
 
   removeImg(){    
@@ -887,6 +898,7 @@ export class UpdateProductSpecComponent implements OnInit{
     this.showRelationships=true;
     this.showSummary=false;
     this.showPreview=false;
+    initFlowbite();
   }
 
   getProdSpecsRel(){
@@ -1178,6 +1190,7 @@ export class UpdateProductSpecComponent implements OnInit{
     this.showRelationships=false;
     this.showSummary=true;
     this.showPreview=false;
+    initFlowbite();
   }
 
   isProdValid(){

--- a/src/app/pages/seller-offerings/offerings/seller-resource-spec/create-resource-spec/create-resource-spec.component.html
+++ b/src/app/pages/seller-offerings/offerings/seller-resource-spec/create-resource-spec/create-resource-spec.component.html
@@ -156,7 +156,7 @@
                             <div class="px-4 py-2 bg-white dark:bg-secondary-300 rounded-b-lg">
                                 <label for="editor" class="sr-only">Publish post</label>
                                 @if(showPreview){
-                                        <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900" [data]="description"></markdown>
+                                        <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900 text-wrap break-all" [data]="description"></markdown>
                                     
                                 }@else{
                                     <textarea id="editor" formControlName="description" rows="8" class="block w-full px-0 text-sm text-gray-800 dark:text-gray-200 bg-white dark:bg-secondary-300 border-0" placeholder="Add product description..." ></textarea>
@@ -214,13 +214,13 @@
                             <tbody>
                                 @for (prod of prodChars; track prod;) {
                                     <tr class="border-b hover:bg-gray-200 dark:bg-secondary-300 dark:border-gray-700 dark:hover:bg-secondary-200">
-                                        <td class="px-6 py-4">
+                                        <td class="px-6 py-4 text-wrap break-all">
                                             {{prod.name}}
                                         </td>
-                                        <td class="hidden lg:table-cell px-6 py-4">
+                                        <td class="hidden lg:table-cell px-6 py-4 text-wrap break-all">
                                             {{prod.description}}                                       
                                         </td>
-                                        <td class="px-6 py-4">
+                                        <td class="px-6 py-4 text-wrap break-all">
                                             @for (char of prod.resourceSpecCharacteristicValue; track char;) {
                                                 @if(char.value){
                                                     {{char.value}} {{char?.unitOfMeasure}},
@@ -399,7 +399,7 @@
                 <div class="m-8">
                     <div>
                         <label class="font-bold text-lg dark:text-white">{{ 'CREATE_PROD_SPEC._product_name' | translate }}</label>
-                        <label class="mb-2 bg-gray-50 border border-gray-300 text-gray-900 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                        <label class="mb-2 bg-gray-50 text-wrap break-all border border-gray-300 text-gray-900 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
                             {{resourceToCreate?.name}}
                         </label>
                     </div>
@@ -420,13 +420,13 @@
                     @if(resourceToCreate?.description !=''){
                         <label class="font-bold text-lg dark:text-white">{{ 'CREATE_PROD_SPEC._product_description' | translate }}</label>
                         <div class="px-4 py-2 bg-white dark:bg-secondary-300 border dark:border-secondary-200 rounded-lg p-4 mb-4">
-                            <markdown class="bg-gray-50 dark:bg-secondary-100 dark:text-white text-gray-900" [data]="resourceToCreate?.description"></markdown>
+                            <markdown class="bg-gray-50 dark:bg-secondary-100 dark:text-white text-gray-900 text-wrap break-all" [data]="resourceToCreate?.description"></markdown>
                         </div>
                     }
                     
                     @if(prodChars.length>0){
                         <label class="font-bold text-lg dark:text-white">{{ 'CREATE_PROD_SPEC._chars' | translate }}</label>
-                        <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white m-4">                        
+                        <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white mb-4">                        
                             <table class="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-200">
                                 <thead class="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-secondary-200 dark:text-white">
                                     <tr>
@@ -444,13 +444,13 @@
                                 <tbody>
                                     @for (prod of resourceToCreate?.resourceSpecCharacteristic; track prod;) {
                                         <tr class="border-b hover:bg-gray-200 dark:bg-secondary-300 dark:border-gray-700 dark:hover:bg-secondary-200">
-                                            <td class="px-6 py-4">
+                                            <td class="px-6 py-4 text-wrap break-all">
                                                 {{prod.name}}
                                             </td>
-                                            <td class="px-6 py-4">
+                                            <td class="px-6 py-4 text-wrap break-all">
                                                 {{prod.description}}                                       
                                             </td>
-                                            <td class="px-6 py-4">
+                                            <td class="px-6 py-4 text-wrap break-all">
                                                 @for (char of prod.resourceSpecCharacteristicValue; track char;) {
                                                     @if(char.value){
                                                         {{char.value}} {{char?.unitOfMeasure}},

--- a/src/app/pages/seller-offerings/offerings/seller-resource-spec/seller-resource-spec.component.html
+++ b/src/app/pages/seller-offerings/offerings/seller-resource-spec/seller-resource-spec.component.html
@@ -136,7 +136,7 @@
                 <tbody>
                     @for (res of resSpecs; track res.id) {
                         <tr class="border-b hover:bg-gray-200 dark:bg-secondary-300 dark:border-gray-700 dark:hover:bg-secondary-200">
-                            <td class="px-6 py-4">
+                            <td class="px-6 py-4 text-wrap break-all">
                                 {{res.name}}
                             </td>
                             <td class="px-6 py-4">

--- a/src/app/pages/seller-offerings/offerings/seller-resource-spec/update-resource-spec/update-resource-spec.component.html
+++ b/src/app/pages/seller-offerings/offerings/seller-resource-spec/update-resource-spec/update-resource-spec.component.html
@@ -234,7 +234,7 @@
                             <div class="px-4 py-2 bg-white dark:bg-secondary-300 rounded-b-lg">
                                 <label for="editor" class="sr-only">Publish post</label>
                                 @if(showPreview){
-                                        <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900" [data]="description"></markdown>
+                                        <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900 text-wrap break-all" [data]="description"></markdown>
                                     
                                 }@else{
                                     <textarea id="editor" formControlName="description" rows="8" class="block w-full px-0 text-sm text-gray-800 dark:text-gray-200 bg-white dark:bg-secondary-300 border-0" placeholder="Add product description..." ></textarea>
@@ -292,13 +292,13 @@
                             <tbody>
                                 @for (prod of prodChars; track prod;) {
                                     <tr class="border-b hover:bg-gray-200 dark:bg-secondary-300 dark:border-gray-700 dark:hover:bg-secondary-200">
-                                        <td class="px-6 py-4">
+                                        <td class="px-6 py-4 text-wrap break-all">
                                             {{prod.name}}
                                         </td>
-                                        <td class="hidden lg:table-cell px-6 py-4">
+                                        <td class="hidden lg:table-cell px-6 py-4 text-wrap break-all">
                                             {{prod.description}}                                       
                                         </td>
-                                        <td class="px-6 py-4">
+                                        <td class="px-6 py-4 text-wrap break-all">
                                             @for (char of prod.resourceSpecCharacteristicValue; track char;) {
                                                 @if(char.value){
                                                     {{char.value}} {{char?.unitOfMeasure}},
@@ -477,7 +477,7 @@
                 <div class="m-8">
                     <div>
                         <label class="font-bold text-lg dark:text-white">{{ 'CREATE_PROD_SPEC._product_name' | translate }}</label>
-                        <label class="mb-2 bg-gray-50 border border-gray-300 text-gray-900 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                        <label class="mb-2 bg-gray-50 text-wrap break-all border border-gray-300 text-gray-900 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
                             {{resourceToUpdate?.name}}
                         </label>
                     </div>
@@ -498,13 +498,13 @@
                     @if(resourceToUpdate?.description !=''){
                         <label class="font-bold text-lg dark:text-white">{{ 'CREATE_PROD_SPEC._product_description' | translate }}</label>
                         <div class="px-4 py-2 bg-white dark:bg-secondary-300 border dark:border-secondary-200 rounded-lg p-4 mb-4">
-                            <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900" [data]="resourceToUpdate?.description"></markdown>
+                            <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900 text-wrap break-all" [data]="resourceToUpdate?.description"></markdown>
                         </div>
                     }
                     
                     @if(prodChars.length>0){
                         <label class="font-bold text-lg dark:text-white">{{ 'CREATE_PROD_SPEC._chars' | translate }}</label>
-                        <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white m-4">                        
+                        <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white mb-4">                        
                             <table class="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-200">
                                 <thead class="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-secondary-200 dark:text-white">
                                     <tr>
@@ -522,13 +522,13 @@
                                 <tbody>
                                     @for (prod of resourceToUpdate?.resourceSpecCharacteristic; track prod;) {
                                         <tr class="border-b hover:bg-gray-200 dark:bg-secondary-300 dark:border-gray-700 dark:hover:bg-secondary-200">
-                                            <td class="px-6 py-4">
+                                            <td class="px-6 py-4 text-wrap break-all">
                                                 {{prod.name}}
                                             </td>
-                                            <td class="hidden lg:table-cell px-6 py-4">
+                                            <td class="hidden lg:table-cell px-6 py-4 text-wrap break-all">
                                                 {{prod.description}}                                       
                                             </td>
-                                            <td class="px-6 py-4">
+                                            <td class="px-6 py-4 text-wrap break-all">
                                                 @for (char of prod.resourceSpecCharacteristicValue; track char;) {
                                                     @if(char.value){
                                                         {{char.value}} {{char?.unitOfMeasure}},

--- a/src/app/pages/seller-offerings/offerings/seller-service-spec/create-service-spec/create-service-spec.component.html
+++ b/src/app/pages/seller-offerings/offerings/seller-service-spec/create-service-spec/create-service-spec.component.html
@@ -156,7 +156,7 @@
                             <div class="px-4 py-2 bg-white dark:bg-secondary-300 rounded-b-lg">
                                 <label for="editor" class="sr-only">Publish post</label>
                                 @if(showPreview){
-                                        <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900" [data]="description"></markdown>
+                                        <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900 text-wrap break-all" [data]="description"></markdown>
                                     
                                 }@else{
                                     <textarea id="editor" formControlName="description" rows="8" class="block w-full px-0 text-sm text-gray-800 dark:text-gray-200 bg-white dark:bg-secondary-300 border-0" placeholder="Add product description..." ></textarea>
@@ -214,13 +214,13 @@
                             <tbody>
                                 @for (prod of prodChars; track prod;) {
                                     <tr class="border-b hover:bg-gray-200 dark:bg-secondary-300 dark:border-gray-700 dark:hover:bg-secondary-200">
-                                        <td class="px-6 py-4">
+                                        <td class="px-6 py-4 text-wrap break-all">
                                             {{prod.name}}
                                         </td>
-                                        <td class="px-6 py-4">
+                                        <td class="px-6 py-4 text-wrap break-all">
                                             {{prod.description}}                                       
                                         </td>
-                                        <td class="px-6 py-4">
+                                        <td class="px-6 py-4 text-wrap break-all">
                                             @for (char of prod.characteristicValueSpecification; track char;) {
                                                 @if(char.value){
                                                     {{char.value}} {{char?.unitOfMeasure}},
@@ -399,7 +399,7 @@
                 <div class="m-8">
                     <div>
                         <label class="font-bold text-lg dark:text-white">{{ 'CREATE_PROD_SPEC._product_name' | translate }}</label>
-                        <label class="mb-2 bg-gray-50 border border-gray-300 text-gray-900 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                        <label class="mb-2 bg-gray-50 text-wrap break-all border border-gray-300 text-gray-900 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
                             {{serviceToCreate?.name}}
                         </label>
                     </div>
@@ -420,13 +420,13 @@
                     @if(serviceToCreate?.description !=''){
                         <label class="font-bold text-lg dark:text-white">{{ 'CREATE_PROD_SPEC._product_description' | translate }}</label>
                         <div class="px-4 py-2 bg-white dark:bg-secondary-300 border dark:border-secondary-200 rounded-lg p-4 mb-2"> 
-                            <markdown class="bg-gray-50 dark:bg-secondary-100 dark:text-white text-gray-900" [data]="serviceToCreate?.description"></markdown>
+                            <markdown class="bg-gray-50 text-wrap break-all dark:bg-secondary-100 dark:text-white text-gray-900 text-wrap break-all" [data]="serviceToCreate?.description"></markdown>
                         </div>
                     }
                     
                     @if(prodChars.length>0){
                         <label class="font-bold text-lg dark:text-white">{{ 'CREATE_PROD_SPEC._chars' | translate }}</label>
-                        <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white m-4">                        
+                        <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white mb-4">                        
                             <table class="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-200">
                                 <thead class="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-secondary-200 dark:text-white">
                                     <tr>
@@ -444,13 +444,13 @@
                                 <tbody>
                                     @for (prod of serviceToCreate?.specCharacteristic; track prod;) {
                                         <tr class="border-b hover:bg-gray-200 dark:bg-secondary-300 dark:border-gray-700 dark:hover:bg-secondary-200">
-                                            <td class="px-6 py-4">
+                                            <td class="px-6 py-4 text-wrap break-all">
                                                 {{prod.name}}
                                             </td>
-                                            <td class="hidden lg:table-cell px-6 py-4">
+                                            <td class="hidden lg:table-cell px-6 py-4 text-wrap break-all">
                                                 {{prod.description}}                                       
                                             </td>
-                                            <td class="px-6 py-4">
+                                            <td class="px-6 py-4 text-wrap break-all">
                                                 @for (char of prod.characteristicValueSpecification; track char;) {
                                                     @if(char.value){
                                                         {{char.value}} {{char?.unitOfMeasure}},

--- a/src/app/pages/seller-offerings/offerings/seller-service-spec/seller-service-spec.component.html
+++ b/src/app/pages/seller-offerings/offerings/seller-service-spec/seller-service-spec.component.html
@@ -137,7 +137,7 @@
             <tbody>
                 @for (serv of servSpecs; track serv.id) {
                     <tr class="border-b hover:bg-gray-200 dark:bg-secondary-300 dark:border-gray-700 dark:hover:bg-secondary-200">
-                        <td class="px-6 py-4">
+                        <td class="px-6 py-4 text-wrap break-all">
                             {{serv.name}}
                         </td>
                         <td class="px-6 py-4">

--- a/src/app/pages/seller-offerings/offerings/seller-service-spec/update-service-spec/update-service-spec.component.html
+++ b/src/app/pages/seller-offerings/offerings/seller-service-spec/update-service-spec/update-service-spec.component.html
@@ -234,7 +234,7 @@
                             <div class="px-4 py-2 bg-white dark:bg-secondary-300 rounded-b-lg">
                                 <label for="editor" class="sr-only">Publish post</label>
                                 @if(showPreview){
-                                        <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900" [data]="description"></markdown>
+                                        <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900 text-wrap break-all" [data]="description"></markdown>
                                     
                                 }@else{
                                     <textarea id="editor" formControlName="description" rows="8" class="block w-full px-0 text-sm text-gray-800 dark:text-gray-200 bg-white dark:bg-secondary-300 border-0" placeholder="Add product description..." ></textarea>
@@ -292,13 +292,13 @@
                             <tbody>
                                 @for (prod of prodChars; track prod;) {
                                     <tr class="border-b hover:bg-gray-200 dark:bg-secondary-300 dark:border-gray-700 dark:hover:bg-secondary-200">
-                                        <td class="px-6 py-4">
+                                        <td class="px-6 py-4 text-wrap break-all">
                                             {{prod.name}}
                                         </td>
-                                        <td class="hidden lg:table-cell px-6 py-4">
+                                        <td class="hidden lg:table-cell px-6 py-4 text-wrap break-all">
                                             {{prod.description}}                                       
                                         </td>
-                                        <td class="px-6 py-4">
+                                        <td class="px-6 py-4 text-wrap break-all">
                                             @for (char of prod.characteristicValueSpecification; track char;) {
                                                 @if(char.value){
                                                     {{char.value}} {{char?.unitOfMeasure}},
@@ -477,7 +477,7 @@
                 <div class="m-8">
                     <div>
                         <label class="font-bold text-lg dark:text-white">{{ 'CREATE_PROD_SPEC._product_name' | translate }}</label>
-                        <label class="mb-2 bg-gray-50 border border-gray-300 text-gray-900 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                        <label class="mb-2 bg-gray-50 text-wrap break-all border border-gray-300 text-gray-900 dark:bg-secondary-300 dark:border-secondary-200 dark:text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
                             {{serviceToUpdate?.name}}
                         </label>
                     </div>
@@ -498,13 +498,13 @@
                     @if(serviceToUpdate?.description !=''){
                         <label class="font-bold text-lg dark:text-white">{{ 'CREATE_PROD_SPEC._product_description' | translate }}</label>
                         <div class="px-4 py-2 bg-white dark:bg-secondary-300 border dark:border-secondary-200 rounded-lg p-4 mb-4"> 
-                            <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900" [data]="serviceToUpdate?.description"></markdown>
+                            <markdown class="bg-gray-50 dark:bg-secondary-300 dark:text-white text-gray-900 text-wrap break-all" [data]="serviceToUpdate?.description"></markdown>
                         </div>
                     }
                     
                     @if(prodChars.length>0){
                         <label class="font-bold text-lg dark:text-white">{{ 'CREATE_PROD_SPEC._chars' | translate }}</label>
-                        <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white m-4">                        
+                        <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-full bg-white mb-4">                        
                             <table class="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-200">
                                 <thead class="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-secondary-200 dark:text-white">
                                     <tr>
@@ -522,13 +522,13 @@
                                 <tbody>
                                     @for (prod of serviceToUpdate?.specCharacteristic; track prod;) {
                                         <tr class="border-b hover:bg-gray-200 dark:bg-secondary-300 dark:border-gray-700 dark:hover:bg-secondary-200">
-                                            <td class="px-6 py-4">
+                                            <td class="px-6 py-4 text-wrap break-all">
                                                 {{prod.name}}
                                             </td>
-                                            <td class="hidden lg:table-cell px-6 py-4">
+                                            <td class="hidden lg:table-cell px-6 py-4 text-wrap break-all">
                                                 {{prod.description}}                                       
                                             </td>
-                                            <td class="px-6 py-4">
+                                            <td class="px-6 py-4 text-wrap break-all">
                                                 @for (char of prod.characteristicValueSpecification; track char;) {
                                                     @if(char.value){
                                                         {{char.value}} {{char?.unitOfMeasure}},

--- a/src/app/services/qr-verifier.service.ts
+++ b/src/app/services/qr-verifier.service.ts
@@ -64,7 +64,7 @@ export class QrVerifierService {
     const systemZoom = width / window.screen.availWidth;
     const left = (width - w) / 2 / systemZoom + dualScreenLeft
     const top = (height - h) / 2 / systemZoom + dualScreenTop
-    const newWindow = window.open(url, title,
+    /*const newWindow = window.open(url, title,
       `
       popup=yes,
       scrollbars=yes,
@@ -73,7 +73,8 @@ export class QrVerifierService {
       top=${top},
       left=${left}
       `
-    )
+    )*/
+    const newWindow = window.open(url)
     newWindow?.focus()
     return newWindow;
   }

--- a/src/app/services/qr-verifier.service.ts
+++ b/src/app/services/qr-verifier.service.ts
@@ -64,7 +64,7 @@ export class QrVerifierService {
     const systemZoom = width / window.screen.availWidth;
     const left = (width - w) / 2 / systemZoom + dualScreenLeft
     const top = (height - h) / 2 / systemZoom + dualScreenTop
-    /*const newWindow = window.open(url, title,
+    const newWindow = window.open(url, title,
       `
       popup=yes,
       scrollbars=yes,
@@ -73,8 +73,7 @@ export class QrVerifierService {
       top=${top},
       left=${left}
       `
-    )*/
-    const newWindow = window.open(url)
+    )
     newWindow?.focus()
     return newWindow;
   }

--- a/src/app/shared/card/card.component.html
+++ b/src/app/shared/card/card.component.html
@@ -154,7 +154,7 @@
             <div class="p-4 lg:p-5 grid grid-cols-1 lg:grid-cols-2 gap-4">
               <div class="justify-start">
                   <h5 class="font-semibold tracking-tight text-lg text-primary-100 dark:text-primary-50">{{ 'CARD._prod_details' | translate }}:</h5>
-                  <markdown class="min-h-19 h-19 dark:text-secondary-50 line-clamp-6" [data]="productOff?.description"></markdown>
+                  <markdown class="min-h-19 h-19 dark:text-secondary-50 line-clamp-6 text-wrap break-all" [data]="productOff?.description"></markdown>
               </div>
               <!--<div class="justify-start">
                 <h5 class="font-semibold tracking-tight text-lg text-primary-100 dark:text-primary-50">{{ 'CARD._comp_profile' | translate }}:</h5>
@@ -170,13 +170,13 @@
               </div>-->
               <div class="justify-start">
                   <h5 class="font-semibold tracking-tight text-lg text-primary-100 dark:text-primary-50">{{ 'CARD._extra_info' | translate }}:</h5>
-                    <ul class="max-w-md space-y-1 list-disc list-inside dark:text-secondary-50">
-                      <li>{{ 'CARD._offer_version' | translate }}: v{{productOff?.version}}</li>
-                      <li>{{ 'CARD._product_name' | translate }}: {{prodSpec.name}}</li>
-                      <li>{{ 'CARD._brand' | translate }}: {{prodSpec.brand}}</li>
-                      <li>{{ 'CARD._last_update' | translate }}: {{productOff?.lastUpdate | date:'dd/MM/yy, HH:mm'}}</li>
-                      <li>{{ 'CARD._product_version' | translate }}: v{{prodSpec.version}}</li>
-                      <li>{{ 'CARD._id_number' | translate }}: XX</li>
+                    <ul class="max-w-md space-y-1 list-disc list-inside dark:text-secondary-50 text-wrap break-all line-clamp-8">
+                      <li class="text-wrap break-all line-clamp-1">{{ 'CARD._offer_version' | translate }}: v{{productOff?.version}}</li>
+                      <li class="text-wrap break-all line-clamp-2">{{ 'CARD._product_name' | translate }}: {{prodSpec.name}}</li>
+                      <li class="text-wrap break-all line-clamp-1">{{ 'CARD._brand' | translate }}: {{prodSpec.brand}}</li>
+                      <li class="text-wrap break-all line-clamp-1">{{ 'CARD._last_update' | translate }}: {{productOff?.lastUpdate | date:'dd/MM/yy, HH:mm'}}</li>
+                      <li class="text-wrap break-all line-clamp-1">{{ 'CARD._product_version' | translate }}: v{{prodSpec.version}}</li>
+                      <li class="text-wrap break-all line-clamp-1">{{ 'CARD._id_number' | translate }}: XX</li>
                     </ul>
               </div>
             </div>

--- a/src/app/shared/categories-panel/categories-panel.component.html
+++ b/src/app/shared/categories-panel/categories-panel.component.html
@@ -1,5 +1,5 @@
 <div class="bg-indigo-300">
-  <div id="chips" class="flex justify-center items-center	min-h-[46px] p-2">
+  <div id="chips" class="flex justify-center items-center	min-h-[58px] p-2">
     <span class="mr-4 ml-2 min-w-fit"><fa-icon [icon]="faFilterList" class="mr-2"></fa-icon>{{ 'CATEGORIES_FILTER._applied_filters' | translate }}</span>
     <div class="overflow-x-auto max-h-[46px] inline-flex">
       @if(selected.length > 0){

--- a/src/app/shared/categories-panel/categories-panel.component.html
+++ b/src/app/shared/categories-panel/categories-panel.component.html
@@ -1,18 +1,23 @@
 <div class="bg-indigo-300">
   <div id="chips" class="flex justify-center items-center	min-h-[46px] p-2">
-    <span class="mr-2"><fa-icon [icon]="faFilterList" class="mr-2"></fa-icon>{{ 'CATEGORIES_FILTER._applied_filters' | translate }}</span>
-    @if(selected.length > 0){
-      @for(category of selected; track category.id; let idx = $index) {
-        <span [id]="'badge-dismiss-'+idx" title="{{category?.name}}" class="inline-flex justify-between items-center px-2 py-1 me-2 text-xs font-medium text-primary-100 border border-1 border-primary-100 bg-secondary-50 rounded dark:bg-secondary-100 dark:text-secondary-50">
-        <span class="line-clamp-1 text-clip"><fa-icon [icon]="faTag" class="mr-2"></fa-icon>{{category?.name}}</span>
-        <button type="button" (click)="notifyDismiss(category)" class="inline-flex items-center p-1 ms-2 text-sm text-primary-100 dark:text-secondary-50 bg-transparent rounded-sm hover:bg-primary-100 hover:text-secondary-50 dark:hover:bg-primary-50 dark:hover:text-primary-100" [attr.data-dismiss-target]="'#badge-dismiss-'+idx" aria-label="Remove">
-        <svg class="w-2 h-2" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14">
-        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6"/>
-        </svg>
-        <span class="sr-only">{{ 'CATEGORIES_FILTER._remove_badge' | translate }}</span>
-        </button>
-      </span>
+    <span class="mr-4 ml-2 min-w-fit"><fa-icon [icon]="faFilterList" class="mr-2"></fa-icon>{{ 'CATEGORIES_FILTER._applied_filters' | translate }}</span>
+    <div class="overflow-x-auto max-h-[46px] inline-flex">
+      @if(selected.length > 0){
+        @for(category of selected; track category.id; let idx = $index) {
+        <span [id]="'badge-dismiss-'+idx" title="{{category?.name}}"
+        class="inline-flex min-w-fit mb-1 justify-between items-center px-2 py-1 me-2 text-xs font-medium text-primary-100 border border-1 border-primary-100 bg-secondary-50 rounded dark:bg-secondary-100 dark:text-secondary-50">
+          <span class="line-clamp-1 min-w-fit"><fa-icon [icon]="faTag" class="mr-2"></fa-icon>{{category?.name}}</span>
+          <button type="button" (click)="notifyDismiss(category)"
+          class="inline-flex items-center p-1 ms-2 text-sm text-primary-100 dark:text-secondary-50 bg-transparent rounded-sm hover:bg-primary-100 hover:text-secondary-50 dark:hover:bg-primary-50 dark:hover:text-primary-100" [attr.data-dismiss-target]="'#badge-dismiss-'+idx" aria-label="Remove">
+          <svg class="w-2 h-2" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14">
+          <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6"/>
+          </svg>
+          <span class="sr-only">{{ 'CATEGORIES_FILTER._remove_badge' | translate }}</span>
+          </button>
+        </span>
+        }
       }
-    }
+    </div>
+
   </div>
 </div>

--- a/src/app/shared/header/header.component.html
+++ b/src/app/shared/header/header.component.html
@@ -148,7 +148,7 @@
       </div>
     }
   </div>
-  <div id="support-dropdown" class="z-30 hidden bg-secondary-50 divide-y divide-primary-100/50 rounded-lg shadow w-44 dark:bg-gray-700 dark:divide-gray-600 ">
+  <div id="support-dropdown" class="z-50 hidden bg-secondary-50 divide-y divide-primary-100/50 rounded-lg shadow w-44 dark:bg-gray-700 dark:divide-gray-600 ">
     <ul class="py-2 text-sm text-gray-700 dark:text-gray-200" aria-labelledby="avatarButton">
       <li>
         <a href="{{ knowledge }}" target="_blank" class="flex w-full justify-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white"><fa-icon [icon]="faBrain" class="mr-2"></fa-icon>{{ 'HEADER._knowledge' | translate }}</a>
@@ -158,7 +158,7 @@
       </li>
     </ul>
   </div>
-  <div id="orgs-dropdown" class="z-30 hidden bg-secondary-50 divide-y divide-primary-100/50 rounded-lg shadow w-44 dark:bg-gray-700 dark:divide-gray-600 ">
+  <div id="orgs-dropdown" class="z-50 hidden bg-secondary-50 divide-y divide-primary-100/50 rounded-lg shadow w-44 dark:bg-gray-700 dark:divide-gray-600 ">
     <ul class="py-2 text-sm text-gray-700 dark:text-gray-200" aria-labelledby="avatarButton">
         @for (org of orgs; track org.id; let idx = $index) {
           @if(org.id != loginInfo.logged_as || loginInfo.logged_as == loginInfo.id){

--- a/src/app/shared/header/header.component.ts
+++ b/src/app/shared/header/header.component.ts
@@ -305,6 +305,7 @@ export class HeaderComponent implements OnInit, AfterViewInit, DoCheck, OnDestro
 
   onLoginClick(){
     if (environment.SIOP_INFO.enabled === true && this.qrVerifier.intervalId === undefined){
+      console.log('SIOP true')
       this.statePair = uuid.v4()
 
       let callbackUrl = environment.SIOP_INFO.callbackURL
@@ -324,6 +325,7 @@ export class HeaderComponent implements OnInit, AfterViewInit, DoCheck, OnDestro
       this.initChecking()
     }
     else if (environment.SIOP_INFO.enabled === false){
+      console.log('SIOP false')
       window.location.replace(`${environment.BASE_URL}` +  '/login')
     }
   }

--- a/src/app/shared/header/header.component.ts
+++ b/src/app/shared/header/header.component.ts
@@ -305,7 +305,6 @@ export class HeaderComponent implements OnInit, AfterViewInit, DoCheck, OnDestro
 
   onLoginClick(){
     if (environment.SIOP_INFO.enabled === true && this.qrVerifier.intervalId === undefined){
-      console.log('SIOP true')
       this.statePair = uuid.v4()
 
       let callbackUrl = environment.SIOP_INFO.callbackURL
@@ -325,7 +324,6 @@ export class HeaderComponent implements OnInit, AfterViewInit, DoCheck, OnDestro
       this.initChecking()
     }
     else if (environment.SIOP_INFO.enabled === false){
-      console.log('SIOP false')
       window.location.replace(`${environment.BASE_URL}` +  '/login')
     }
   }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -81,7 +81,8 @@
             "_seamless_desc": "Follow our easy process to integrate and deploy your chosen services swiftly.",
             "_join": "Join as customer",
             "_explore": "Explore the catalogue",
-            "_contact": "Contact us"
+            "_contact": "Contact us",
+            "_description": "The marketplace is actually free to browse. Take a look at the catalogue contents, search for the services you need, verify the different offerings, get in touch with the service providers to better understand the proposal and acquire the desired service."
         },
         "PROVIDERS": {
             "_title": "For providers",
@@ -94,7 +95,10 @@
             "_reach_desc": "Once verified, your services will be accessible to a wide European audience, ready to grow your business.",
             "_join": "Join as provider",
             "_onboard": "Onboard the marketplace",
-            "_contact": "Contact us"
+            "_contact": "Contact us",
+            "_description_start": "Qualify you company through the reference",
+            "_link": "Company Onboarding process",
+            "_description_end": "and then start describing your offerings through the Offering qualification process and star being visible on the market inside this trustable catalogue."
         }
     },
     "EXPLORE": {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -485,7 +485,10 @@
         "_finish": "Finish",
         "_summary": "Product's summary",
         "_update_prod": "Update product",
-        "_verify": "Verify Certificates"
+        "_verify": "Verify Certificates",
+        "_how_to_verify": "How to get a valid VC of the certificate?",
+        "_verify_text": "To get a valid VC of the certificate you can access the ",
+        "_dome_trust": "DOME Trust Service Provider for Certification"
     },
     "CREATE_RES_SPEC": {
         "_back": "Back",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -81,7 +81,8 @@
             "_seamless_desc": "Follow our easy process to integrate and deploy your chosen services swiftly.",
             "_join": "Join as customer",
             "_explore": "Explore the catalogue",
-            "_contact": "Contact us"
+            "_contact": "Contact us",
+            "_description": "The marketplace is actually free to browse. Take a look at the catalogue contents, search for the services you need, verify the different offerings, get in touch with the service providers to better understand the proposal and acquire the desired service."
         },
         "PROVIDERS": {
             "_title": "For providers",
@@ -94,7 +95,10 @@
             "_reach_desc": "Once verified, your services will be accessible to a wide European audience, ready to grow your business.",
             "_join": "Join as provider",
             "_onboard": "Onboard the marketplace",
-            "_contact": "Contact us"
+            "_contact": "Contact us",
+            "_description_start": "Qualify you company through the reference",
+            "_link": "Company Onboarding process",
+            "_description_end": "and then start describing your offerings through the Offering qualification process and star being visible on the market inside this trustable catalogue."
         }
     },
     "EXPLORE": {

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -485,7 +485,10 @@
         "_finish": "Finish",
         "_summary": "Product's summary",
         "_update_prod": "Update product",
-        "_verify": "Verify Certificates"
+        "_verify": "Verify Certificates",
+        "_how_to_verify": "How to get a valid VC of the certificate?",
+        "_verify_text": "To get a valid VC of the certificate you can access the ",
+        "_dome_trust": "DOME Trust Service Provider for Certification"
     },
     "CREATE_RES_SPEC": {
         "_back": "Back",

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -39,5 +39,6 @@ export const environment = {
     TICKETING_SYSTEM_URL: "",
     KNOWLEDGE_BASE_URL: "",
     SEARCH_ENABLED: true,
-    PURCHASE_ENABLED: false
+    PURCHASE_ENABLED: false,
+    DOME_TRUST_LINK: "https://dome-certification.dome-marketplace-sbx.org"
 };

--- a/src/environments/environment.production.ts
+++ b/src/environments/environment.production.ts
@@ -38,5 +38,6 @@ export const environment = {
     TICKETING_SYSTEM_URL: "",
     KNOWLEDGE_BASE_URL: "",
     SEARCH_ENABLED: true,
-    PURCHASE_ENABLED: false
+    PURCHASE_ENABLED: false,
+    DOME_TRUST_LINK: "https://dome-certification.dome-marketplace.org"
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -40,5 +40,6 @@ export const environment = {
     TICKETING_SYSTEM_URL: "",
     KNOWLEDGE_BASE_URL: "",
     SEARCH_ENABLED: true,
-    PURCHASE_ENABLED: false
+    PURCHASE_ENABLED: false,
+    DOME_TRUST_LINK: "https://dome-certification.dome-marketplace.org"
 };

--- a/src/index.html
+++ b/src/index.html
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="assets/chatbot/images/dome_logo.PNG">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Blinker:wght@300;400;500;600;700&display=swap">
+  <link href="https://cdn.jsdelivr.net/npm/flowbite@2.4.1/dist/flowbite.min.css" rel="stylesheet" />
   <script>
     // On page load or when changing themes, best to add inline in `head` to avoid FOUC
     if (localStorage.getItem('color-theme') === 'dark' || (!('color-theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
@@ -18,5 +19,6 @@
 </head>
 <body class="h-screen bg-white dark:bg-gray-900"> <!-- class="dark:bg-gray-900" style="background-image: url('assets/logos/dome-logo-element-colour.png');"-->
   <app-root></app-root>
+  <script src="../node_modules/flowbite/dist/flowbite.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Solves :
- Missing space around text when see details for product offer (Ticket#83441)
- Read more/Read less need to be disable or hide when only one row in License (Ticket#83448)

- Create offer problems (Ticket#83458) + Solved same problems in all the forms (not just offer's forms).
- Missing background around button on white theme on product specification (Ticket#83457)
- Quick preview of offer broken length for Product name (Ticket#83460)
- New catalogue name missing limitation for length of name (Ticket#83459)
- Not possible to see categories names when selected 15 in filters (Ticket#83438)
- Missing to see part of search text when selected 15 categories (Ticket#83439)
- Not visible back button when select many categories and watch details on offer (Ticket#83442)
- Drop down of support not show correctly when category is selected in Applied filters (Ticket#83454)